### PR TITLE
Add Dependabot cooldown and auto-merge for patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,18 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 5
+    semver-major-days: 7
+    semver-minor-days: 5
+    semver-patch-days: 3
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 5
+    semver-major-days: 7
+    semver-minor-days: 5
+    semver-patch-days: 3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- **Cooldown** in `dependabot.yml` — new releases bake before Dependabot opens a PR (3 days patch / 5 minor / 7 major). Fewer, safer PRs; avoids landing a release that gets yanked days later.
- **Auto-merge workflow** — patch/minor bumps merge themselves once CI is green. **Major bumps still wait for a human.**

## How it gates

Auto-merge uses GitHub native auto-merge, which only merges once the required checks pass. Backed by the new branch-protection rule on `main`:
- Required checks: `test`, `lint`, `scan_js`, `scan_ruby`
- PR required, enforced for admins, 0 required approvals (so Dependabot/you self-merge)

## Context

Cleared the existing backlog of 10 Dependabot PRs (rails, puma 8, view_component, solid_queue, etc.) alongside this. Only #80 (actions/checkout 6→7) left open — its stale branch pinned an old Brakeman; a rebase will green it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UD3SPaKwcyMia8aSaNBehJ