### PR TITLE
Let settled signings and understated starters rank over a season

### DIFF
--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -39,6 +39,10 @@ class ExpectedPoints
   # else's team sheet. Three thousand minutes at Newcastle says nothing about
   # whether he is first choice at Tottenham, so his record is allowed to argue for
   # half a match and no more until he has played some football for the new side.
+  #
+  # That caution is right for the coming week and too harsh for the rest of the
+  # season, by when an established signing will long since have settled in. A
+  # rest-of-season horizon lifts the cap so his record does more of the talking.
   NEW_CLUB_MINUTES = 0.5
 
   # FPL's scoring table, by position.
@@ -149,7 +153,7 @@ class ExpectedPoints
   end
 
   def initialize(rankings, stats:, fixtures_by_team:, season_started: true, gameweeks_played: nil,
-                 managers: nil, movers: [], crowd_weight: CROWD_WEIGHT)
+                 managers: nil, movers: [], crowd_weight: CROWD_WEIGHT, new_club_minutes: NEW_CLUB_MINUTES)
     @rankings = rankings
     @stats = stats
     @fixtures_by_team = fixtures_by_team
@@ -158,6 +162,7 @@ class ExpectedPoints
     @managers = managers.to_i
     @movers = movers.to_set
     @crowd_weight = crowd_weight
+    @new_club_minutes = new_club_minutes
   end
 
   # How much football there has been to measure against. Before the season starts
@@ -289,7 +294,7 @@ class ExpectedPoints
     return nil if played.nil?
 
     regular = [ played / regular_minutes, 1.0 ].min
-    @movers.include?(ranking.player_id) ? [ regular, NEW_CLUB_MINUTES ].min : regular
+    @movers.include?(ranking.player_id) ? [ regular, @new_club_minutes ].min : regular
   end
 
   def minutes_played(ranking)

--- a/app/services/rest_of_season_forecast.rb
+++ b/app/services/rest_of_season_forecast.rb
@@ -9,7 +9,11 @@
 class RestOfSeasonForecast < Forecaster
   # The crowd's order is an early-season reading, so over a whole season it is
   # trusted less and each player's own record does more of the talking.
-  CROWD_WEIGHT = 0.75
+  CROWD_WEIGHT = 0.85
+
+  # A player who changed clubs will have settled in long before the season is out,
+  # so the half-a-match caution on his old minutes is eased for this horizon.
+  NEW_CLUB_MINUTES = 0.75
 
   private
 
@@ -22,6 +26,6 @@ class RestOfSeasonForecast < Forecaster
   end
 
   def model_overrides
-    { crowd_weight: CROWD_WEIGHT }
+    { crowd_weight: CROWD_WEIGHT, new_club_minutes: NEW_CLUB_MINUTES }
   end
 end

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -164,6 +164,22 @@ class ExpectedPointsTest < ActiveSupport::TestCase
            "the crowd simply gets less of the say"
   end
 
+  test "an established signing is held to half a match, and a longer horizon eases that" do
+    rankings = [ ranking(1) ]
+    stats = { 1 => regular(minutes: 3000.0) } # a full record, earned at his old club
+
+    capped = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                season_started: false, movers: [ 1 ]).call
+    eased = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                               season_started: false, movers: [ 1 ], new_club_minutes: 0.75).call
+    settled = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: false, movers: []).call
+
+    assert_equal 45, capped[1][:working][:minutes], "a mover's record argues for half a match"
+    assert eased[1][:points] > capped[1][:points], "a longer horizon eases the cap"
+    assert eased[1][:points] < settled[1][:points], "but not all the way to a settled regular"
+  end
+
   test "a rush for the exit drops a player hard and at once" do
     rankings = [ ranking(1), ranking(2) ]
     owned = regular(owned: 10.0) # a tenth of 10m managers, so a million owners

--- a/test/services/rest_of_season_forecast_test.rb
+++ b/test/services/rest_of_season_forecast_test.rb
@@ -73,6 +73,17 @@ class RestOfSeasonForecastTest < ActiveSupport::TestCase
     assert_operator season, :<, weekly, "a season out trusts the early-season crowd less"
   end
 
+  test "records that it eased the new-club cap for the season horizon" do
+    WeeklyForecast.call(gameweek: @next)
+    RestOfSeasonForecast.call(gameweek: @next)
+
+    weekly = Forecast.find_by(horizon: "gameweek").strategy.strategy_config[:new_club_minutes]
+    season = Forecast.find_by(horizon: "rest_of_season").strategy.strategy_config[:new_club_minutes]
+
+    assert_equal RestOfSeasonForecast::NEW_CLUB_MINUTES, season
+    assert_operator season, :>, weekly, "a settled signing is trusted more over a whole season"
+  end
+
   test "refuses to write a position it cannot score anybody in" do
     Match.destroy_all
 


### PR DESCRIPTION
## Context

Two players the rest-of-season table read too low — for two different reasons, confirmed from each forecast's stored `working`:

- **Rogers** (mover, 3280 mins on record) was pinned at `minutes=45` by the **new-club cap** (`NEW_CLUB_MINUTES=0.5`) — halving an established starter to "half a match until he plays for the new club." Right for next week, too harsh over 38 games.
- **Isak** (not a mover; only **694 recorded minutes** → 29% minutes share) leant on the crowd that knew he's a nailed starter — and the earlier crowd mute (0.75) pulled him down with it.

## Change

- **New-club cap eased for RoS: 0.5 → 0.75.** `new_club_minutes` is now an injectable `ExpectedPoints` parameter (same pattern as `crowd_weight`), threaded through the strategy tag via `model_overrides` so a stored forecast still records the settings it was made under.
- **Crowd mute softened for RoS: 0.75 → 0.85.** Rebalances the blunt crowd knob so it stops over-penalising established players whose record understates them, while keeping most of the correction on the hyped keeper.

Weekly forecasts are untouched (both knobs default to the single-gameweek values).

## Effect (rest of season)

| Player | Before | After |
|---|---|---|
| Isak (FWD) | 12 | **10** (into the top ten) |
| Rogers (MID) | 23 | **12** |
| Lammens (GK) | 4 | 3 (still corrected, below Donnarumma & Roefs) |

## Verification
- 149 tests, 0 failures; RuboCop clean.
- New tests: the mover cap and its horizon easing (`ExpectedPoints`), and the strategy tag recording the eased `new_club_minutes` for RoS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFun5BJMAmpUBXMUkY3hLn