### PR TITLE
Redesign player ranking row

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,10 @@
 @import "tailwindcss";
+
+.ff-crest {
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}

--- a/app/components/player_card_component.html.erb
+++ b/app/components/player_card_component.html.erb
@@ -1,0 +1,43 @@
+<div class="flex items-stretch h-24 rounded-xl overflow-hidden bg-white border border-zinc-200 shadow-sm cursor-pointer"
+     onclick="Turbo.visit('<%= helpers.player_path(player) %>')"
+     role="link" tabindex="0"
+     onkeydown="if(event.key === 'Enter') Turbo.visit('<%= helpers.player_path(player) %>')">
+  <div class="w-[54px] shrink-0 flex items-center justify-center text-[32px] font-extrabold tracking-[-0.03em] leading-none tabular-nums text-zinc-900"><%= rank %></div>
+
+  <div class="relative flex-1 overflow-hidden">
+    <div class="absolute inset-0 z-0 overflow-hidden [clip-path:polygon(18px_0,100%_0,calc(100%_-_32px)_100%,0_100%)]">
+      <div class="absolute inset-0" style="background-color: <%= color %>"></div>
+      <% if team&.badge_url %>
+        <span class="ff-crest absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.2]"
+              style="-webkit-mask-image:url('<%= team.badge_url %>');mask-image:url('<%= team.badge_url %>');background-color:<%= team.on_light? ? '#0d0d0d' : '#ffffff' %>"></span>
+        <span class="absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.22]">
+          <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain" %>
+        </span>
+      <% end %>
+    </div>
+
+    <div class="relative z-[1] h-full flex flex-col justify-center pl-6 <%= text_class %>">
+      <div class="text-[10px] font-bold tracking-[-0.02em] uppercase opacity-80 leading-none mb-[3px] whitespace-nowrap"><%= player.first_name %></div>
+      <div class="text-[21px] font-extrabold tracking-[-0.02em] uppercase leading-none whitespace-nowrap"><%= player.short_name %></div>
+      <div class="text-[10.5px] font-bold opacity-95 leading-none mt-[5px] whitespace-nowrap flex items-center gap-1.5">
+        <span><%= team&.short_name %></span>
+        <% if cost %>
+          <span class="opacity-50 font-normal">/</span><span class="tabular-nums"><%= cost %></span>
+        <% end %>
+        <% if ownership %>
+          <span class="opacity-50 font-normal">/</span><span class="tabular-nums"><%= ownership %></span>
+        <% end %>
+      </div>
+    </div>
+
+    <% if player.cutout_url %>
+      <span class="absolute right-6 bottom-0 h-[100px] z-[2] pointer-events-none">
+        <%= image_tag player.cutout_url, alt: "",
+              class: "block h-full w-auto object-bottom drop-shadow-[0_5px_9px_rgba(0,0,0,0.22)]",
+              onerror: "this.parentElement.remove()" %>
+      </span>
+    <% end %>
+  </div>
+
+  <div class="w-[54px] shrink-0 flex items-center justify-center text-[32px] font-extrabold tracking-[-0.03em] leading-none text-zinc-900"><%= grade %></div>
+</div>

--- a/app/components/player_card_component.html.erb
+++ b/app/components/player_card_component.html.erb
@@ -17,7 +17,9 @@
     </div>
 
     <div class="relative z-[1] h-full flex flex-col justify-center pl-6 <%= text_class %>">
-      <div class="text-[10px] font-bold tracking-[-0.02em] uppercase opacity-80 leading-none mb-[3px] whitespace-nowrap"><%= player.first_name %></div>
+      <% if player.given_name.present? %>
+        <div class="text-[10px] font-bold tracking-[-0.02em] uppercase opacity-80 leading-none mb-[3px] whitespace-nowrap"><%= player.given_name %></div>
+      <% end %>
       <div class="text-[21px] font-extrabold tracking-[-0.02em] uppercase leading-none whitespace-nowrap"><%= player.short_name %></div>
       <div class="text-[10.5px] font-bold opacity-95 leading-none mt-[5px] whitespace-nowrap flex items-center gap-1.5">
         <span><%= team&.short_name %></span>

--- a/app/components/player_card_component.rb
+++ b/app/components/player_card_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PlayerCardComponent < PlayerRowComponent
+end

--- a/app/components/player_row_component.html.erb
+++ b/app/components/player_row_component.html.erb
@@ -21,7 +21,9 @@
         </div>
 
         <div class="relative z-[1] min-w-0 grid grid-rows-[0px_12px_2px_26px_2px_14px] justify-items-start">
-          <span class="row-start-2 self-end leading-none text-xs font-bold tracking-[-0.02em] uppercase opacity-80 whitespace-nowrap"><%= player.first_name %></span>
+          <% if player.given_name.present? %>
+            <span class="row-start-2 self-end leading-none text-xs font-bold tracking-[-0.02em] uppercase opacity-80 whitespace-nowrap"><%= player.given_name %></span>
+          <% end %>
           <span class="row-start-4 self-center leading-none text-2xl font-extrabold tracking-[-0.02em] uppercase whitespace-nowrap"><%= player.short_name %></span>
           <span class="row-start-6 self-start leading-none text-[12.5px] font-bold whitespace-nowrap flex items-center gap-[7px]">
             <span><%= team&.name %></span>

--- a/app/components/player_row_component.html.erb
+++ b/app/components/player_row_component.html.erb
@@ -1,0 +1,55 @@
+<tr class="cursor-pointer group"
+    onclick="Turbo.visit('<%= helpers.player_path(player) %>')"
+    role="link" tabindex="0"
+    onkeydown="if(event.key === 'Enter') Turbo.visit('<%= helpers.player_path(player) %>')">
+  <td class="w-[104px] pl-[10px] text-center align-middle bg-white border-y border-l border-zinc-200 rounded-l-xl group-hover:bg-zinc-50">
+    <span class="text-[46px] font-extrabold tracking-[-0.03em] leading-none tabular-nums text-zinc-900"><%= rank %></span>
+  </td>
+
+  <td class="p-0 w-full align-middle bg-white border-y border-zinc-200 group-hover:bg-zinc-50">
+    <div class="relative h-[104px] w-full overflow-hidden">
+      <div class="relative z-[1] flex items-center h-full w-full pl-10 <%= text_class %>">
+        <div class="absolute inset-0 z-0 overflow-hidden [clip-path:polygon(26px_0,100%_0,calc(100%_-_44px)_100%,0_100%)]">
+          <div class="absolute inset-0" style="background-color: <%= color %>"></div>
+          <% if team&.badge_url %>
+            <span class="ff-crest absolute right-0 top-1/2 -translate-y-1/2 h-[152px] w-[152px] pointer-events-none opacity-[.2]"
+                  style="-webkit-mask-image:url('<%= team.badge_url %>');mask-image:url('<%= team.badge_url %>');background-color:<%= team.on_light? ? '#0d0d0d' : '#ffffff' %>"></span>
+            <span class="absolute right-0 top-1/2 -translate-y-1/2 h-[152px] w-[152px] pointer-events-none opacity-[.22]">
+              <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain" %>
+            </span>
+          <% end %>
+        </div>
+
+        <div class="relative z-[1] min-w-0 grid grid-rows-[0px_12px_2px_26px_2px_14px] justify-items-start">
+          <span class="row-start-2 self-end leading-none text-xs font-bold tracking-[-0.02em] uppercase opacity-80 whitespace-nowrap"><%= player.first_name %></span>
+          <span class="row-start-4 self-center leading-none text-2xl font-extrabold tracking-[-0.02em] uppercase whitespace-nowrap"><%= player.short_name %></span>
+          <span class="row-start-6 self-start leading-none text-[12.5px] font-bold whitespace-nowrap flex items-center gap-[7px]">
+            <span><%= team&.name %></span>
+            <% if cost %>
+              <span class="opacity-50 font-normal">/</span>
+              <span class="tabular-nums"><%= cost %></span>
+            <% end %>
+            <% if ownership %>
+              <span class="opacity-50 font-normal">/</span>
+              <span class="tabular-nums">
+                <%= ownership %><% if transfer_movement %><span class="text-[10.5px] opacity-80 ml-[3px] tabular-nums"><%= transfer_movement %></span><% end %>
+              </span>
+            <% end %>
+          </span>
+        </div>
+      </div>
+
+      <% if player.cutout_url %>
+        <span class="absolute right-8 bottom-0 h-[112px] z-[2] pointer-events-none">
+          <%= image_tag player.cutout_url, alt: "",
+                class: "block h-full w-auto object-contain object-bottom drop-shadow-[0_6px_11px_rgba(0,0,0,0.24)]",
+                onerror: "this.parentElement.remove()" %>
+        </span>
+      <% end %>
+    </div>
+  </td>
+
+  <td class="w-[104px] text-center align-middle bg-white border-y border-r border-zinc-200 rounded-r-xl group-hover:bg-zinc-50">
+    <span class="text-[46px] font-extrabold tracking-[-0.03em] leading-none text-zinc-900"><%= grade %></span>
+  </td>
+</tr>

--- a/app/components/player_row_component.rb
+++ b/app/components/player_row_component.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class PlayerRowComponent < ViewComponent::Base
+  def initialize(ranking:, player:, facts:)
+    @ranking = ranking
+    @player = player
+    @facts = facts || {}
+  end
+
+  private
+
+  attr_reader :ranking, :player, :facts
+
+  def rank
+    ranking.bot_rank || "-"
+  end
+
+  def grade
+    ranking.grade
+  end
+
+  def team
+    player.team
+  end
+
+  def color
+    team&.color || Team::DEFAULT_COLOR
+  end
+
+  def text_class
+    team&.on_light? ? "text-zinc-900" : "text-white"
+  end
+
+  def cost
+    helpers.player_price(facts["now_cost"])
+  end
+
+  def ownership
+    value = facts["selected_by_percent"]
+    return nil if value.blank?
+
+    format("%.1f%%", value.to_f)
+  end
+
+  def transfer_movement
+    net = facts["transfers_in"].to_i - facts["transfers_out"].to_i
+    return nil if net.zero?
+
+    "#{net.positive? ? '▲' : '▼'}#{abbreviate(net.abs)}"
+  end
+
+  def abbreviate(number)
+    number >= 1_000 ? "#{(number / 1_000.0).round}k" : number.to_s
+  end
+end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,6 +1,6 @@
 class PlayersController < ApplicationController
   # Facts about a player we report rather than rate. See #load_row_facts.
-  ROW_FACT_TYPES = %w[now_cost selected_by_percent].freeze
+  ROW_FACT_TYPES = %w[now_cost selected_by_percent transfers_in transfers_out].freeze
 
   # How deep a list is worth reading in each position. Past this you are scrolling
   # through players nobody is choosing between, and the tail is where a forecast is

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -74,6 +74,11 @@ class Player < ApplicationRecord
     "https://resources.premierleague.com/premierleague25/photos/players/#{size}/#{code}.png"
   end
 
+  def cutout_url
+    return nil unless code.present?
+    "https://resources.premierleague.com/premierleague25/photos/players/110x140/#{code}.png"
+  end
+
   # Get chance_of_playing from statistics for the current/next gameweek
   # Uses find on loaded association to avoid N+1 queries when statistics are preloaded
   def chance_of_playing(gameweek = nil)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -36,6 +36,13 @@ class Player < ApplicationRecord
     read_attribute(:short_name).presence || last_name
   end
 
+  def given_name
+    surname = short_name.to_s
+    return "" if surname.blank?
+
+    first_name.to_s.sub(/\s*#{Regexp.escape(surname)}\s*\z/i, "").strip
+  end
+
   def slug
     full_name.parameterize
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,16 @@
 class Team < ApplicationRecord
+  COLORS = {
+    "ARS" => "#EF0107", "AVL" => "#670E36", "BOU" => "#DA291C", "BRE" => "#E30613",
+    "BHA" => "#0057B8", "CHE" => "#034694", "COV" => "#6CB4EE", "CRY" => "#1B458F",
+    "EVE" => "#003399", "FUL" => "#1D1D1D", "HUL" => "#F5A12D", "IPS" => "#3A64A3",
+    "LEE" => "#1D428A", "LIV" => "#C8102E", "MCI" => "#6CABDD", "MUN" => "#DA291C",
+    "NEW" => "#241F20", "NFO" => "#DD0000", "TOT" => "#132257", "SUN" => "#EB172B"
+  }.freeze
+
+  LIGHT_SHIRTS = %w[MCI COV HUL].freeze
+
+  DEFAULT_COLOR = "#374151".freeze
+
   # Validations
   validates :name, presence: true
   validates :short_name, presence: true
@@ -16,6 +28,14 @@ class Team < ApplicationRecord
   def badge_url
     return nil unless code.present?
     "https://resources.premierleague.com/premierleague25/badges/#{code}.svg"
+  end
+
+  def color
+    COLORS.fetch(short_name, DEFAULT_COLOR)
+  end
+
+  def on_light?
+    LIGHT_SHIRTS.include?(short_name)
   end
 
   # FPL strength ratings (higher = stronger), split by venue. Used to rate how

--- a/app/services/consensus_ranking.rb
+++ b/app/services/consensus_ranking.rb
@@ -1,7 +1,7 @@
 # Returns bot rankings for a given gameweek and position.
 # Simplified from the original consensus system now that we only have bot forecasts.
 class ConsensusRanking
-  Ranking = Struct.new(:player_id, :name, :team_id, :position, :bot_rank, :score, :tier, keyword_init: true)
+  Ranking = Struct.new(:player_id, :name, :team_id, :position, :bot_rank, :score, :tier, :grade, keyword_init: true)
 
   def self.for_week_and_position(gameweek, position = nil, team_id = nil, horizon: "gameweek")
     new(gameweek, position, team_id, horizon: horizon).rankings

--- a/app/services/tier_calculator.rb
+++ b/app/services/tier_calculator.rb
@@ -53,6 +53,24 @@ class TierCalculator
     end
   end
 
+  GRADE_LETTERS = { 1 => "A", 2 => "B", 3 => "C", 4 => "D", 5 => "F" }.freeze
+
+  BAND_FLOORS = { 1 => 4.25, 2 => 3.25, 3 => 2.25, 4 => 1.25, 5 => 0.25 }.freeze
+
+  def self.grade_from_points(points)
+    return "F" if points.nil?
+
+    tier = tier_from_points(points)
+    "#{GRADE_LETTERS[tier]}#{grade_suffix(points.to_f - BAND_FLOORS[tier])}"
+  end
+
+  def self.grade_suffix(fraction)
+    return "+" if fraction >= 0.6667
+    return "-" if fraction < 0.3333
+
+    ""
+  end
+
   def self.calculate_player_tier(forecast, _position = nil)
     tier_info(tier_from_points(forecast.score))
   end
@@ -60,12 +78,10 @@ class TierCalculator
   private
 
   def assign_tier(ranking)
-    ranking.tier = calculate_tier(ranking.score)
+    points = per_gameweek(ranking.score)
+    ranking.tier = self.class.tier_from_points(points)
+    ranking.grade = self.class.grade_from_points(points)
     ranking
-  end
-
-  def calculate_tier(score)
-    self.class.tier_from_points(per_gameweek(score))
   end
 
   def per_gameweek(score)

--- a/app/services/tier_calculator.rb
+++ b/app/services/tier_calculator.rb
@@ -58,9 +58,11 @@ class TierCalculator
   BAND_FLOORS = { 1 => 4.25, 2 => 3.25, 3 => 2.25, 4 => 1.25, 5 => 0.25 }.freeze
 
   def self.grade_from_points(points)
-    return "F" if points.nil?
+    return "-" if points.nil?
 
     tier = tier_from_points(points)
+    return "-" if tier == 5
+
     "#{GRADE_LETTERS[tier]}#{grade_suffix(points.to_f - BAND_FLOORS[tier])}"
   end
 

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -50,47 +50,28 @@
 
     <!-- Rankings Table -->
     <% if @consensus_rankings.any? %>
-      <div class="rounded-lg border border-zinc-200 bg-white text-sm/6 text-zinc-950">
-        <div class="flex items-center gap-4 px-3 sm:px-6 py-2 text-zinc-500 font-medium border-b border-zinc-200">
-          <div class="shrink-0 w-10">Rank</div>
-          <div class="flex-1">Player</div>
-          <div class="flex items-center shrink-0 text-xs">
-            <div class="w-20 lg:w-28 text-center" title="How he looks for this gameweek">Outlook</div>
-          </div>
-        </div>
+      <div class="hidden md:block overflow-x-auto">
+        <table class="w-full min-w-[720px] table-fixed border-separate border-spacing-y-2 text-zinc-950">
+          <thead>
+            <tr class="text-[10px] uppercase tracking-wider text-zinc-400 font-bold">
+              <th class="w-[104px] pb-2 text-center">Rank</th>
+              <th class="pb-2 pl-10 text-left">Player</th>
+              <th class="w-[104px] pb-2 text-center">Grade</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @consensus_rankings.each do |ranking| %>
+              <% player = @players_by_id[ranking.player_id] %>
+              <%= render PlayerRowComponent.new(ranking: ranking, player: player, facts: @row_facts&.dig(player.id)) %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="md:hidden flex flex-col gap-2">
         <% @consensus_rankings.each do |ranking| %>
           <% player = @players_by_id[ranking.player_id] %>
-          <div class="flex items-center gap-4 px-3 sm:px-6 py-3 border-b border-zinc-100 cursor-pointer hover:bg-zinc-50"
-               onclick="Turbo.visit('<%= player_path(player) %>')"
-               role="link"
-               tabindex="0"
-               onkeydown="if(event.key === 'Enter') Turbo.visit('<%= player_path(player) %>')">
-            <div class="shrink-0 w-10 whitespace-nowrap">
-              <span class="text-base font-semibold text-zinc-900"><%= ranking.bot_rank || '-' %></span>
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-3 sm:gap-4">
-                <%= render PlayerAvatarComponent.new(player: player, size: :medium) %>
-                <div class="min-w-0 flex-1">
-                  <span class="font-medium text-lg text-zinc-900"><%= player.short_name %></span>
-                  <div class="text-zinc-900 flex flex-wrap items-center gap-1">
-                    <%= render TeamBadgeComponent.new(team: player.team) %>
-                    <span><%= player.team&.name %></span>
-                    <% player_facts(@row_facts&.dig(player.id)).each do |fact| %>
-                      <span class="opacity-40" aria-hidden="true">·</span>
-                      <span class="tabular-nums opacity-70"><%= fact %></span>
-                    <% end %>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="flex items-center justify-end shrink-0">
-              <div class="w-20 lg:w-28 text-center">
-                <span class="inline-flex items-center justify-center w-16 h-12 text-5xl select-none"
-                      title="<%= tier_info(ranking.tier)&.dig(:name) %>"><%= tier_symbol(ranking.tier) %></span>
-              </div>
-            </div>
-          </div>
+          <%= render PlayerCardComponent.new(ranking: ranking, player: player, facts: @row_facts&.dig(player.id)) %>
         <% end %>
       </div>
     <% else %>


### PR DESCRIPTION
Replaces the circle-avatar rankings list with a row where our analysis frames the player: white **rank** on the left, white **grade** on the right, and the club-colour player card between them.

## What changed
- **Layout** — `PlayerRowComponent` (desktop table) + `PlayerCardComponent` (mobile card, short team names). Table on `md+`, cards below. Built with Tailwind v4.
- **Team colours** — `Team::COLORS` map + `#color` / `#on_light?` (FPL exposes no colours).
- **Cutouts** — `Player#cutout_url` uses the `110x140` path, which covers players the `250x250` path is missing (e.g. van Dijk); a missing image is dropped.
- **Grades** — `TierCalculator.grade_from_points` splits each tier band into +/base/- thirds → A+…D-; the bottom tier reads "–" (unranked) rather than F, since that tail is where the forecast is least reliable. `Ranking` gains a `grade` field.
- **Crest** — shown as a contrasting silhouette layered under the true-colour crest, centred behind the player, so it reads on every club including same-hue ones.
- **Names** — `Player#given_name` strips the display name off `first_name` so the forename line never repeats the surname (Igor Jesus, Richarlison show the display name only; Evanilson shows "Francisco / EVANILSON").
- Keeps **Inter** as the typeface.

## Notes / follow-ups (not in this PR)
- Transfer movement is 0 pre-season; **price-change isn't synced** yet (no cost arrow).
- Fixtures in the row and server-side sort remain open.

## Tests
149 tests pass · Rubocop clean · Brakeman 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYv6LCZ7Q3keNpjsm7f26D