### PR TITLE
Fix club crests vanishing for same-hue clubs (CORS mask)

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,10 +1,1 @@
 @import "tailwindcss";
-
-.ff-crest {
-  mask-size: contain;
-  mask-repeat: no-repeat;
-  mask-position: center;
-  -webkit-mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-}

--- a/app/components/player_card_component.html.erb
+++ b/app/components/player_card_component.html.erb
@@ -8,8 +8,9 @@
     <div class="absolute inset-0 z-0 overflow-hidden [clip-path:polygon(18px_0,100%_0,calc(100%_-_32px)_100%,0_100%)]">
       <div class="absolute inset-0" style="background-color: <%= color %>"></div>
       <% if team&.badge_url %>
-        <span class="ff-crest absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.2]"
-              style="-webkit-mask-image:url('<%= team.badge_url %>');mask-image:url('<%= team.badge_url %>');background-color:<%= team.on_light? ? '#0d0d0d' : '#ffffff' %>"></span>
+        <span class="absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.2]">
+          <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain #{team.on_light? ? 'brightness-0' : 'brightness-0 invert'}" %>
+        </span>
         <span class="absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.22]">
           <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain" %>
         </span>

--- a/app/components/player_row_component.html.erb
+++ b/app/components/player_row_component.html.erb
@@ -12,8 +12,9 @@
         <div class="absolute inset-0 z-0 overflow-hidden [clip-path:polygon(26px_0,100%_0,calc(100%_-_44px)_100%,0_100%)]">
           <div class="absolute inset-0" style="background-color: <%= color %>"></div>
           <% if team&.badge_url %>
-            <span class="ff-crest absolute right-0 top-1/2 -translate-y-1/2 h-[152px] w-[152px] pointer-events-none opacity-[.2]"
-                  style="-webkit-mask-image:url('<%= team.badge_url %>');mask-image:url('<%= team.badge_url %>');background-color:<%= team.on_light? ? '#0d0d0d' : '#ffffff' %>"></span>
+            <span class="absolute right-0 top-1/2 -translate-y-1/2 h-[152px] w-[152px] pointer-events-none opacity-[.2]">
+              <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain #{team.on_light? ? 'brightness-0' : 'brightness-0 invert'}" %>
+            </span>
             <span class="absolute right-0 top-1/2 -translate-y-1/2 h-[152px] w-[152px] pointer-events-none opacity-[.22]">
               <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain" %>
             </span>


### PR DESCRIPTION
## Problem

Club crests were invisible again on production for same-hue clubs — Liverpool, Forest, Spurs — the exact case the layered-silhouette work was meant to fix.

## Root cause

The contrasting silhouette behind the player cutout was drawn with `mask-image` pointing at the Premier League badge SVG on `resources.premierleague.com`. That CDN returns **no `Access-Control-Allow-Origin` header**, and browsers gate cross-origin CSS masks behind CORS — so the silhouette layer silently never rendered in a real browser. Only the true-colour crest survived, and for clubs whose crest hue matches the card background it's effectively invisible.

It appeared "fixed" earlier only because it was verified via rendered HTML, never in an actual browser where the mask fails.

## Fix

Draw the silhouette as a second `<img>` filtered with `brightness-0` (plus `invert` for dark shirts) instead of a CSS mask. CSS filters apply to cross-origin images without CORS, so the contrast halo is restored with an identical look — no external dependency on CORS headers.

Applies to both desktop (`PlayerRowComponent`) and mobile (`PlayerCardComponent`). Removed the now-unused `.ff-crest` mask CSS.

## Verification

- 149 tests pass, Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)