### PR TITLE
Spell out FPL's abbreviated player names

### DIFF
--- a/app/components/player_card_component.html.erb
+++ b/app/components/player_card_component.html.erb
@@ -21,7 +21,7 @@
       <% if player.given_name.present? %>
         <div class="text-[10px] font-bold tracking-[-0.02em] uppercase opacity-80 leading-none mb-[3px] whitespace-nowrap"><%= player.given_name %></div>
       <% end %>
-      <div class="text-[21px] font-extrabold tracking-[-0.02em] uppercase leading-none whitespace-nowrap"><%= player.short_name %></div>
+      <div class="text-[21px] font-extrabold tracking-[-0.02em] uppercase leading-none whitespace-nowrap"><%= player.display_name %></div>
       <div class="text-[10.5px] font-bold opacity-95 leading-none mt-[5px] whitespace-nowrap flex items-center gap-1.5">
         <span><%= team&.short_name %></span>
         <% if cost %>

--- a/app/components/player_row_component.html.erb
+++ b/app/components/player_row_component.html.erb
@@ -25,7 +25,7 @@
           <% if player.given_name.present? %>
             <span class="row-start-2 self-end leading-none text-xs font-bold tracking-[-0.02em] uppercase opacity-80 whitespace-nowrap"><%= player.given_name %></span>
           <% end %>
-          <span class="row-start-4 self-center leading-none text-2xl font-extrabold tracking-[-0.02em] uppercase whitespace-nowrap"><%= player.short_name %></span>
+          <span class="row-start-4 self-center leading-none text-2xl font-extrabold tracking-[-0.02em] uppercase whitespace-nowrap"><%= player.display_name %></span>
           <span class="row-start-6 self-start leading-none text-[12.5px] font-bold whitespace-nowrap flex items-center gap-[7px]">
             <span><%= team&.name %></span>
             <% if cost %>

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -37,10 +37,11 @@ class Player < ApplicationRecord
   end
 
   def given_name
-    surname = short_name.to_s
-    return "" if surname.blank?
+    player_name.given
+  end
 
-    first_name.to_s.sub(/\s*#{Regexp.escape(surname)}\s*\z/i, "").strip
+  def display_name
+    player_name.display
   end
 
   def slug
@@ -97,6 +98,10 @@ class Player < ApplicationRecord
   end
 
   private
+
+  def player_name
+    @player_name ||= PlayerName.new(first_name: first_name, last_name: last_name, short_name: short_name)
+  end
 
   def resolve_gameweek_id(gameweek)
     gameweek ||= Gameweek.current_gameweek || Gameweek.next_gameweek

--- a/app/models/player_name.rb
+++ b/app/models/player_name.rb
@@ -1,0 +1,90 @@
+# FPL squeezes a player's name into one narrow column, so it abbreviates:
+# "J.Timber", "Bruno G.", "Pedro Porro". Our rankings have two lines to play
+# with, so we undo the squeeze: the given name on top, the name they are known
+# by underneath, and never the same name twice.
+class PlayerName
+  NICKNAME = /\s'[^']*'/                 # Rodrigo 'Rodri'
+  LEADING_INITIALS = /\A(?:\p{L}\.)+/     # J.Timber, P.M.Sarr
+  TRAILING_INITIAL = /[.\s](\p{L})\.?\z/  # Bruno G., Tóth.A
+
+  def initialize(first_name:, last_name:, short_name:)
+    @first_name = first_name.to_s.strip
+    @last_name = last_name.to_s.strip
+    @short_name = short_name.to_s.strip
+  end
+
+  def display
+    @display ||= without_given_name(spell_out(short_name))
+  end
+
+  # Whatever comes before the name they are known by: "Francisco Evanilson"
+  # alongside "Evanilson" leaves us with "Francisco", and "Alysson Edward
+  # Franco" alongside "Alysson" leaves us with nothing to add
+  def given
+    @given ||= first_name.gsub(NICKNAME, "").split.take_while { |part| !shown?(part) }.join(" ")
+  end
+
+  private
+
+  attr_reader :first_name, :last_name, :short_name
+
+  def spell_out(name)
+    expand_trailing_initial(expand_leading_initials(name))
+  end
+
+  # "J.Timber" is Jurriën Timber, "O.Dango" is Dango Ouattara
+  def expand_leading_initials(name)
+    initials = name[LEADING_INITIALS]
+    return name unless initials
+
+    letters = initials.scan(/\p{L}/)
+    return name.sub(LEADING_INITIALS, "") if letters.all? { |letter| first_name_initial?(letter) }
+
+    surname_for(letters.first) || name
+  end
+
+  # "Bruno G." is Bruno Guimarães, "Tóth.A" is Alex Tóth
+  def expand_trailing_initial(name)
+    match = name.match(TRAILING_INITIAL)
+    return name unless match
+
+    without_initial = name.sub(TRAILING_INITIAL, "")
+    return without_initial if first_name_initial?(match[1])
+
+    surname = surname_for(match[1])
+    surname ? "#{without_initial} #{surname}" : name
+  end
+
+  # "Pedro Porro" leads with the given name we are already showing above it
+  def without_given_name(name)
+    parts = name.split
+    return name unless parts.size > first_name_parts.size
+    return name unless same?(parts.first(first_name_parts.size).join(" "), first_name)
+
+    parts.drop(first_name_parts.size).join(" ")
+  end
+
+  def shown?(part)
+    display.split.any? { |shown| same?(part, shown) }
+  end
+
+  def first_name_initial?(initial)
+    first_name_parts.any? { |part| same?(part.first, initial) }
+  end
+
+  def surname_for(initial)
+    last_name.split.find { |part| same?(part.first, initial) }
+  end
+
+  def first_name_parts
+    @first_name_parts ||= first_name.split
+  end
+
+  def same?(one, other)
+    fold(one) == fold(other)
+  end
+
+  def fold(name)
+    ActiveSupport::Inflector.transliterate(name).downcase
+  end
+end

--- a/test/models/player_name_test.rb
+++ b/test/models/player_name_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class PlayerNameTest < ActiveSupport::TestCase
+  def name_for(first_name, last_name, short_name)
+    player_name = PlayerName.new(first_name: first_name, last_name: last_name, short_name: short_name)
+    [ player_name.given, player_name.display ]
+  end
+
+  test "keeps a plain name as it is" do
+    assert_equal [ "Bukayo", "Saka" ], name_for("Bukayo", "Saka", "Saka")
+  end
+
+  test "drops the initial FPL uses in place of the first name" do
+    assert_equal [ "Jurriën", "Timber" ], name_for("Jurriën", "Timber", "J.Timber")
+    assert_equal [ "Pape Matar", "Sarr" ], name_for("Pape Matar", "Sarr", "P.M.Sarr")
+    assert_equal [ "Alex", "Tóth" ], name_for("Alex", "Tóth", "Tóth.A")
+  end
+
+  test "spells out the initial FPL uses in place of the surname" do
+    assert_equal [ "Bruno", "Guimarães" ], name_for("Bruno", "Guimarães Rodriguez Moura", "Bruno G.")
+    assert_equal [ "Dango", "Ouattara" ], name_for("Dango", "Ouattara", "O.Dango")
+  end
+
+  test "does not repeat the first name in the display name" do
+    assert_equal [ "Pedro", "Porro" ], name_for("Pedro", "Porro Sauceda", "Pedro Porro")
+    assert_equal [ "Marc", "Guiu" ], name_for("Marc", "Guiu Paz", "Marc Guiu")
+  end
+
+  test "shows nothing above a player known by their given name" do
+    assert_equal [ "", "Gabriel" ], name_for("Gabriel", "dos Santos Magalhães", "Gabriel")
+    assert_equal [ "", "Joelinton" ], name_for("Joelinton Cássio", "Apolinário de Lira", "Joelinton")
+    assert_equal [ "", "Rodrigo" ], name_for("Rodrigo 'Rodri'", "Hernandez Cascante", "Rodrigo")
+  end
+
+  test "keeps the first name of a player known by their middle name" do
+    assert_equal [ "Francisco", "Evanilson" ], name_for("Francisco Evanilson", "de Lima Barbosa", "Evanilson")
+    assert_equal [ "Igor", "Thiago" ], name_for("Igor Thiago", "Nascimento Rodrigues", "Thiago")
+  end
+
+  test "ignores accents when comparing names" do
+    assert_equal [ "", "Yeremy" ], name_for("Yéremy", "Pino Santos", "Yeremy")
+  end
+
+  test "leaves an abbreviation it cannot spell out alone" do
+    assert_equal [ "Junior", "Kroupi.Jr" ], name_for("Junior", "Kroupi", "Kroupi.Jr")
+  end
+end


### PR DESCRIPTION
FPL squeezes a player's name into one narrow column, so it abbreviates: `J.Timber`, `Bruno G.`, `Pedro Porro`. Our ranking rows have two lines, and `Player#given_name` only dropped the first name when it literally ended with the web name, so anything abbreviated was printed twice.

`PlayerName` undoes the squeeze instead of working around it: it drops an initial standing in for the first name, spells out one standing in for the surname, and never repeats a name across the two lines.

| FPL data | Before | Now |
|---|---|---|
| Pedro / Porro Sauceda / `Pedro Porro` | PEDRO / PEDRO PORRO | PEDRO / **PORRO** |
| Matheus / Nunes / `Matheus N.` | MATHEUS / MATHEUS N. | MATHEUS / **NUNES** |
| Jurriën / Timber / `J.Timber` | JURRIËN / J.TIMBER | JURRIËN / **TIMBER** |
| Bruno / Guimarães… / `Bruno G.` | BRUNO / BRUNO G. | BRUNO / **GUIMARÃES** |
| Dango / Ouattara / `O.Dango` | DANGO / O.DANGO | DANGO / **OUATTARA** |
| Joelinton Cássio / … / `Joelinton` | JOELINTON CÁSSIO / JOELINTON | **JOELINTON** |

49 of 564 players change, all checked by hand against the dev database. No player repeats a name part across the two lines.

The big line is no longer FPL's `web_name` verbatim: FPL abbreviates because it has one column, and we move that disambiguation to the given name above.

`short_name` still returns FPL's raw value, so alphabetical sorting and the SEO link text are unchanged. Only the ranking row and card use `display_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcEXK6XpvnLXMHoUuywLeo