### PR TITLE
Restore the accents FPL strips from short names

### DIFF
--- a/app/models/player_name.rb
+++ b/app/models/player_name.rb
@@ -14,7 +14,7 @@ class PlayerName
   end
 
   def display
-    @display ||= without_given_name(spell_out(short_name))
+    @display ||= restore_accents(without_given_name(spell_out(short_name)))
   end
 
   # Whatever comes before the name they are known by: "Francisco Evanilson"
@@ -62,6 +62,26 @@ class PlayerName
     return name unless same?(parts.first(first_name_parts.size).join(" "), first_name)
 
     parts.drop(first_name_parts.size).join(" ")
+  end
+
+  # FPL strips the accents from some short names ("Bayindir"), but the full
+  # name spells them properly ("Bayındır")
+  def restore_accents(name)
+    name.split.map { |part| accented(part) }.join(" ")
+  end
+
+  def accented(part)
+    return part if accented?(part)
+
+    name_parts.find { |candidate| same?(candidate, part) && accented?(candidate) } || part
+  end
+
+  def accented?(part)
+    fold(part) != part.downcase
+  end
+
+  def name_parts
+    @name_parts ||= first_name_parts + last_name.split
   end
 
   def shown?(part)

--- a/test/models/player_name_test.rb
+++ b/test/models/player_name_test.rb
@@ -37,8 +37,14 @@ class PlayerNameTest < ActiveSupport::TestCase
     assert_equal [ "Igor", "Thiago" ], name_for("Igor Thiago", "Nascimento Rodrigues", "Thiago")
   end
 
-  test "ignores accents when comparing names" do
-    assert_equal [ "", "Yeremy" ], name_for("Yéremy", "Pino Santos", "Yeremy")
+  test "restores the accents FPL strips from the short name" do
+    assert_equal [ "Altay", "Bayındır" ], name_for("Altay", "Bayındır", "Bayindir")
+    assert_equal [ "Nico", "González" ], name_for("Nico", "González Iglesias", "N.Gonzalez")
+    assert_equal [ "", "Yéremy" ], name_for("Yéremy", "Pino Santos", "Yeremy")
+  end
+
+  test "keeps a short name spelled better than the full name" do
+    assert_equal [ "Benjamin", "Šeško" ], name_for("Benjamin", "Sesko", "Šeško")
   end
 
   test "leaves an abbreviation it cannot spell out alone" do


### PR DESCRIPTION
FPL spells some short names without their accents (`Bayindir`, `Kinsky`, `Martinez`) even though the full name it sends us has them (`Bayındır`, `Kinský`, `Martínez`). `PlayerName` now prefers the properly spelled part when the two match once transliterated.

Twelve players gain accents: Hincapié, Gómez, Vušković, Benítez, Yéremy, Bayındır, Domínguez, Kinský, Martínez (x2), Bajčetić, González.

It only ever adds accents, never removes them, so a short name spelled better than the full name is left alone: Benjamin Sesko stays **Šeško**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcEXK6XpvnLXMHoUuywLeo