### PR TITLE
Read the same season, the right horizon, and the right peer group

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -148,8 +148,8 @@ class PlayersController < ApplicationController
   end
 
   def load_consensus_rankings
-    rankings = ConsensusRanking.for_week_and_position(@gameweek, @position_filter, @team_filter, horizon: @horizon)
-    @consensus_rankings = TierCalculator.new(rankings, position: @position_filter, points_divisor: tier_divisor).call
+    rankings = ConsensusRanking.call(@gameweek, @position_filter, @team_filter, horizon: @horizon)
+    @consensus_rankings = TierCalculator.call(rankings, position: @position_filter, points_divisor: tier_divisor)
     @tier_groups = @consensus_rankings.group_by(&:tier)
   end
 

--- a/app/services/availability.rb
+++ b/app/services/availability.rb
@@ -1,0 +1,102 @@
+# How much of a run of gameweeks each player is expected to be fit for, as a
+# share of them. Only players with something wrong get an entry: everybody else
+# is fit and needs no opinion.
+#
+# FPL tells us whether a man can play this Saturday, never how long he is out
+# for. Over one week those are the same question. Over a season they are not, and
+# reading "0% chance of playing" as a verdict on the next nine months writes off
+# a player with a fortnight's groin strain. That is why a fit-again Saliba was
+# missing from a rest-of-season page entirely.
+#
+# So: where FPL names a return date, count the weeks after it. Where it does not,
+# assume a long absence rather than a permanent one.
+class Availability < ApplicationService
+  FIT = "a".freeze
+  DOUBTFUL = "d".freeze
+  GONE = "u".freeze # left the league: on loan, sold abroad, released
+
+  # A date FPL writes as "Expected back 21 Aug" or "Suspended until 6 Sep". The
+  # year is never given, so it is taken from the day the news was posted.
+  RETURN_DATE = /(?:Expected back|until)\s+(\d{1,2}\s+\w{3})/i
+  CHANCE = /(\d+)%\s+chance of playing/i
+
+  # What "Unknown return date" is worth, and it is a guess.
+  #
+  # FPL publishes nothing about severity, and of the players carrying that phrase
+  # today, more than half are down as "Knee", which covers both a bruise and a
+  # torn cruciate. A lookup table of injury types would be invention dressed up as
+  # data, so we assume the bad end instead: better to leave out a player who could
+  # have played than to recommend one who is not coming back.
+  #
+  # It stops being a guess once we have watched these flags clear. We already
+  # store every player's fitness week by week, so by Christmas this can be the
+  # measured figure rather than an assumed one.
+  UNKNOWN_LAYOFF = 3.months
+
+  # A doubt is about one weekend, not a season. Over a long horizon it costs him
+  # that week and nothing more.
+  ASSUMED_CHANCE = 75.0
+  CERTAIN = 100.0
+
+  def initialize(players, gameweeks:)
+    @players = players
+    @gameweeks = gameweeks.to_a
+  end
+
+  def call
+    return {} if @gameweeks.empty?
+
+    @players.each_with_object({}) do |player, shares|
+      share = share_for(player)
+      shares[player.id] = share unless share.nil?
+    end
+  end
+
+  private
+
+  def share_for(player)
+    return nil if player.status.blank? || player.status == FIT
+    return 0.0 if player.status == GONE
+    return doubtful_share(player) if player.status == DOUBTFUL
+
+    weeks_after(returns_on(player))
+  end
+
+  # He misses at most the coming week, and even that is not certain.
+  def doubtful_share(player)
+    chance = player.news.to_s[CHANCE, 1]&.to_f || ASSUMED_CHANCE
+    ((@gameweeks.size - 1) + (chance / CERTAIN)) / @gameweeks.size
+  end
+
+  def weeks_after(date)
+    @gameweeks.count { |gameweek| gameweek.start_time.to_date >= date } / @gameweeks.size.to_f
+  end
+
+  # Never sooner than the week after next, whatever the arithmetic says. FPL has
+  # him at no chance for the coming one, and a flag posted months ago that is
+  # still flying means he has not recovered on schedule, not that he is back.
+  def returns_on(player)
+    [ named_return(player) || flagged_on(player) + UNKNOWN_LAYOFF, earliest_return ].compact.max
+  end
+
+  def earliest_return
+    @gameweeks.second&.start_time&.to_date
+  end
+
+  # "21 Aug" with no year. FPL posts the news before the return, so the date meant
+  # is the first one on or after the day it was posted.
+  def named_return(player)
+    written = player.news.to_s[RETURN_DATE, 1]
+    return nil if written.blank?
+
+    posted = flagged_on(player)
+    date = Date.parse("#{written} #{posted.year}")
+    date < posted.to_date ? date.next_year : date
+  rescue Date::Error
+    nil
+  end
+
+  def flagged_on(player)
+    player.news_added || Time.current
+  end
+end

--- a/app/services/consensus_ranking.rb
+++ b/app/services/consensus_ranking.rb
@@ -1,11 +1,7 @@
 # Returns bot rankings for a given gameweek and position.
 # Simplified from the original consensus system now that we only have bot forecasts.
-class ConsensusRanking
+class ConsensusRanking < ApplicationService
   Ranking = Struct.new(:player_id, :name, :team_id, :position, :bot_rank, :score, :tier, :grade, keyword_init: true)
-
-  def self.for_week_and_position(gameweek, position = nil, team_id = nil, horizon: "gameweek")
-    new(gameweek, position, team_id, horizon: horizon).rankings
-  end
 
   def initialize(gameweek, position = nil, team_id = nil, horizon: "gameweek")
     @gameweek = gameweek
@@ -14,7 +10,7 @@ class ConsensusRanking
     @horizon = horizon
   end
 
-  def rankings
+  def call
     return [] unless gameweek_record
 
     build_rankings

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -14,12 +14,32 @@
 #   rankings         - ConsensusRanking::Ranking (player_id, position, team_id)
 #   stats            - { player_id => { stat_type => Float } }
 #   fixtures_by_team - { team_id => [{ difficulty:, opponent:, home: }] } this week's games
-class ExpectedPoints
+class ExpectedPoints < ApplicationService
   STAT_TYPES = %w[
     season_minutes last_season_minutes chance_of_playing
     expected_goals_per_90 expected_goal_involvements_per_90 clean_sheets_per_90 saves_per_90
     selected_by_percent transfers_in transfers_out now_cost form points_per_game season_bonus
+    last_season_expected_goals_per_90 last_season_expected_goal_involvements_per_90
+    last_season_clean_sheets_per_90 last_season_saves_per_90 last_season_bonus
   ].freeze
+
+  # Where each measurement is read from before a ball is kicked.
+  #
+  # All of these describe the same football, so they have to come from the same
+  # season. Take a player's minutes from last season and his scoring rate from a
+  # season he spent outside the league and he is credited with a full campaign of
+  # turning up and doing nothing, which is how a promoted club's defender came to
+  # outrank the man half the game had picked ahead of him. FPL also zeroes the
+  # current-season fields over the summer, so reading them then hands every player
+  # in the game the same bare appearance points.
+  LAST_SEASON = {
+    "season_minutes" => "last_season_minutes",
+    "season_bonus" => "last_season_bonus",
+    "expected_goals_per_90" => "last_season_expected_goals_per_90",
+    "expected_goal_involvements_per_90" => "last_season_expected_goal_involvements_per_90",
+    "clean_sheets_per_90" => "last_season_clean_sheets_per_90",
+    "saves_per_90" => "last_season_saves_per_90"
+  }.freeze
 
   FULL_MATCH = 90.0
   FULLY_AVAILABLE = 100.0
@@ -119,11 +139,11 @@ class ExpectedPoints
   # rest-of-season horizon turns it down so its own record does more of the talking.
   CROWD_WEIGHT = 1.0
 
-  # The cheapest tenth of a position, where ownership stops being a verdict.
-  # Everybody needs a bench and somebody has to fill it, so a quarter of the game
-  # owning the cheapest keeper is a budget decision, not a prediction that he will
-  # play. Down here the crowd is allowed to mark a player down, which still means
-  # something, but never to carry one up.
+  # The cheapest tenth of a position, where ownership stops being a verdict on
+  # quality. Everybody needs a bench and somebody has to fill it, so a quarter of
+  # the game owning the cheapest keeper is a budget decision rather than a claim
+  # that he is any good. It is still a claim that he plays, which is why these
+  # players are judged against each other rather than ignored. See #bracket_of.
   CHEAPEST = 0.1
 
   # What this week's transfers say, measured against the people who actually own
@@ -153,11 +173,13 @@ class ExpectedPoints
   end
 
   def initialize(rankings, stats:, fixtures_by_team:, season_started: true, gameweeks_played: nil,
-                 managers: nil, movers: [], crowd_weight: CROWD_WEIGHT, new_club_minutes: NEW_CLUB_MINUTES)
+                 managers: nil, movers: [], fitness: {},
+                 crowd_weight: CROWD_WEIGHT, new_club_minutes: NEW_CLUB_MINUTES)
     @rankings = rankings
     @stats = stats
     @fixtures_by_team = fixtures_by_team
     @season_started = season_started
+    @fitness = fitness
     @gameweeks_played = weeks_of_football(gameweeks_played)
     @managers = managers.to_i
     @movers = movers.to_set
@@ -203,13 +225,14 @@ class ExpectedPoints
   end
 
   # What a player standing where he stands with the crowd is typically worth, read
-  # off our own figures for the position. Where we agree with them this changes
-  # nothing; where we disagree, each pulls the other.
+  # off our own figures for the players he is judged against. Where we agree with
+  # them this changes nothing; where we disagree, each pulls the other.
   def crowd_estimate(ranking)
     return nil if conviction(ranking).zero?
 
-    curve = crowd_curve(ranking.position)
-    place = crowd_order(ranking.position).index(ranking.player_id)
+    peers = bracket_of(ranking)
+    curve = crowd_curve(peers)
+    place = crowd_order(peers).index(ranking.player_id)
     return nil if curve.empty? || place.nil?
 
     curve[[ place, curve.size - 1 ].min]
@@ -222,14 +245,35 @@ class ExpectedPoints
     return ours if theirs.nil?
 
     share = crowd_share(ranking)
-    (1 - share) * ours + share * capped(ranking, ours, theirs)
+    (1 - share) * ours + share * theirs
   end
 
-  # Among the cheapest in a position, backing can only count against a player. It
-  # is the one place where being popular tells us nothing: the money had to go
-  # somewhere.
-  def capped(ranking, ours, theirs)
-    bargain?(ranking) ? [ theirs, ours ].min : theirs
+  # Who a player's backing is measured against.
+  #
+  # Ownership means two different things depending on price. At the top of a
+  # position it says a manager thinks this player is worth funding from the rest
+  # of his side. At the bottom it mostly says he plays: somebody has to fill the
+  # slot, so the game piles into whichever cheap defender is nailed on, and that
+  # is a statement about the team sheet rather than about quality.
+  #
+  # Read against the whole position, an enabler is promoted into the company of
+  # players managers actually paid for. Read against the other cheap players, the
+  # same backing answers the only question worth asking of them, which is which
+  # of them starts. So the cheap are ranked among themselves, and the best the
+  # crowd can say of one is that he is the best of the cheap.
+  #
+  # This used to be a cap: among the cheapest, backing could only ever count
+  # against a player, never for him. That kept enablers down and also made the
+  # crowd mute exactly where it knows most, so two four million pound defenders
+  # at the same club could not be told apart by the forty-fold difference in how
+  # many managers had picked them.
+  def bracket_of(ranking)
+    [ ranking.position, bargain?(ranking) ]
+  end
+
+  def in_bracket(bracket)
+    position, cheap = bracket
+    in_position(position).select { |other| bargain?(other) == cheap }
   end
 
   def bargain?(ranking)
@@ -261,20 +305,20 @@ class ExpectedPoints
     @position_prices[position] ||= in_position(position).map { |other| price(other) }.reject(&:zero?)
   end
 
-  # The position's own figures, best first: the shape of what is on offer.
-  def crowd_curve(position)
+  # The bracket's own figures, best first: the shape of what is on offer in it.
+  def crowd_curve(bracket)
     @crowd_curve ||= {}
-    @crowd_curve[position] ||= in_position(position).filter_map { |ranking| our_estimate(ranking) }.sort.reverse
+    @crowd_curve[bracket] ||= in_bracket(bracket).filter_map { |ranking| our_estimate(ranking) }.sort.reverse
   end
 
-  # Everyone in the position, in the order the crowd has put its money. Players the
+  # Everyone in the bracket, in the order the crowd has put its money. Players the
   # crowd has treated identically are separated by our own reading of them, so a
   # tie cannot hand somebody another player's standing by accident.
-  def crowd_order(position)
+  def crowd_order(bracket)
     @crowd_order ||= {}
-    @crowd_order[position] ||= in_position(position)
-                               .sort_by { |ranking| [ -conviction(ranking), -our_estimate(ranking).to_f ] }
-                               .map(&:player_id)
+    @crowd_order[bracket] ||= in_bracket(bracket)
+                              .sort_by { |ranking| [ -conviction(ranking), -our_estimate(ranking).to_f ] }
+                              .map(&:player_id)
   end
 
   def in_position(position)
@@ -298,16 +342,31 @@ class ExpectedPoints
   end
 
   def minutes_played(ranking)
-    optional_stat(ranking, @season_started ? "season_minutes" : "last_season_minutes")
+    optional_stat(ranking, season_or_last("season_minutes"))
+  end
+
+  # What he did, read from whichever season we are measuring. See LAST_SEASON.
+  def record(ranking, type)
+    stat(ranking, season_or_last(type))
+  end
+
+  def season_or_last(type)
+    @season_started ? type : LAST_SEASON.fetch(type)
   end
 
   def regular_minutes
     @gameweeks_played * FULL_MATCH * REGULAR_SHARE
   end
 
-  # Absent means fit. Reading this as a plain zero would mark every healthy player
-  # unavailable.
+  # Whether he can play at all, which multiplies the finished answer.
+  #
+  # For the coming week that is FPL's fitness flag, and absent means fit: reading
+  # a missing figure as a plain zero would mark every healthy player unavailable.
+  # Over a longer horizon the question changes from "is he fit on Saturday" to
+  # "how much of this is he fit for", and the caller answers it. See Availability.
   def availability(ranking)
+    return @fitness[ranking.player_id] if @fitness.key?(ranking.player_id)
+
     (optional_stat(ranking, "chance_of_playing") || FULLY_AVAILABLE) / FULLY_AVAILABLE
   end
 
@@ -333,7 +392,7 @@ class ExpectedPoints
     played = minutes_played(ranking).to_f
     return 0.0 if played.zero?
 
-    stat(ranking, "season_bonus") / (played / FULL_MATCH)
+    record(ranking, "season_bonus") / (played / FULL_MATCH)
   end
 
   # Nought before a ball is kicked, and nought for a player with no record, both of
@@ -352,21 +411,21 @@ class ExpectedPoints
 
   # Involvements less the goals themselves, never negative however FPL rounds.
   def assist_points(ranking)
-    created = [ stat(ranking, "expected_goal_involvements_per_90") - goals(ranking), 0.0 ].max
+    created = [ record(ranking, "expected_goal_involvements_per_90") - goals(ranking), 0.0 ].max
     ASSIST * created
   end
 
   def clean_sheet_points(ranking)
-    CLEAN_SHEET.fetch(ranking.position, 0) * stat(ranking, "clean_sheets_per_90")
+    CLEAN_SHEET.fetch(ranking.position, 0) * record(ranking, "clean_sheets_per_90")
   end
 
   # Only ever anything for a keeper, so this needs no position of its own.
   def save_points(ranking)
-    stat(ranking, "saves_per_90") / SAVES_PER_POINT
+    record(ranking, "saves_per_90") / SAVES_PER_POINT
   end
 
   def goals(ranking)
-    stat(ranking, "expected_goals_per_90")
+    record(ranking, "expected_goals_per_90")
   end
 
   # A rate over a handful of minutes is mostly luck, so it is pulled towards

--- a/app/services/forecaster.rb
+++ b/app/services/forecaster.rb
@@ -113,16 +113,26 @@ class Forecaster < ApplicationService
   end
 
   def expected_points_for(players)
-    ExpectedPoints.new(
-      players.map { |player| ranking_for(player) },
+    ExpectedPoints.call(players.map { |player| ranking_for(player) }, **inputs_for(players))
+  end
+
+  def inputs_for(players)
+    {
       stats: stats_for(players),
       fixtures_by_team: fixtures_by_team,
       season_started: Gameweek.finished.exists?,
       gameweeks_played: Gameweek.finished.count,
       managers: total_managers,
       movers: movers,
-      **model_overrides
-    ).call
+      fitness: fitness(players)
+    }.merge(model_overrides)
+  end
+
+  # How fit a player is over this horizon. For one week FPL's own flag answers it,
+  # so nothing is passed and the model reads the flag. A horizon long enough for
+  # an injury to heal has to ask a different question, and its subclass says so.
+  def fitness(_players)
+    {}
   end
 
   # How this horizon departs from the default model. The weekly forecast takes it

--- a/app/services/fpl/sync_player_histories.rb
+++ b/app/services/fpl/sync_player_histories.rb
@@ -18,8 +18,27 @@ module Fpl
     # Statistic type => the key to read from FPL's past-season entry.
     STAT_TYPES = {
       "last_season_points" => "total_points",
-      "last_season_minutes" => "minutes"
+      "last_season_minutes" => "minutes",
+      "last_season_bonus" => "bonus"
     }.freeze
+
+    # The same per-90 rates bootstrap publishes for the current season, worked out
+    # from the season's totals so a forecast can read either interchangeably.
+    # Without these, a player's minutes come from last season while his scoring
+    # rate comes from a season he may not have played in.
+    RATE_TYPES = {
+      "last_season_expected_goals_per_90" => "expected_goals",
+      "last_season_expected_goal_involvements_per_90" => "expected_goal_involvements",
+      "last_season_clean_sheets_per_90" => "clean_sheets",
+      "last_season_saves_per_90" => "saves"
+    }.freeze
+
+    MINUTES_IN_A_MATCH = 90.0
+
+    # What we currently record from a past season. Bump it when that set changes
+    # and every player is asked again on the next run, rather than being left with
+    # a partial history that nothing notices.
+    RECORD_VERSION = 2.0
 
     REQUEST_DELAY = 0.5 # seconds between requests, to stay a polite guest
 
@@ -61,7 +80,7 @@ module Fpl
     end
 
     def players_missing_history(gameweek)
-      asked = Statistic.where(gameweek: gameweek, type: [ STAT_TYPES.keys.first, CHECKED ]).select(:player_id)
+      asked = Statistic.where(gameweek: gameweek, type: CHECKED, value: RECORD_VERSION).select(:player_id)
       Player.where.not(id: asked).to_a
     end
 
@@ -98,13 +117,14 @@ module Fpl
       season = latest_past_season(player)
       return [ checked_record(player, gameweek, now) ] if season.nil?
 
-      totals(player, gameweek, season, now) << checked_record(player, gameweek, now)
+      totals(player, gameweek, season, now) +
+        rates(player, gameweek, season, now) +
+        [ checked_record(player, gameweek, now) ]
     end
 
     # A receipt that we asked, so a player with no past is not asked about again.
     def checked_record(player, gameweek, now)
-      { player_id: player.id, gameweek_id: gameweek.id, type: CHECKED,
-        value: 1.0, created_at: now, updated_at: now }
+      record(player, gameweek, CHECKED, RECORD_VERSION, now)
     end
 
     def totals(player, gameweek, season, now)
@@ -112,9 +132,27 @@ module Fpl
         value = season[key]
         next if value.nil?
 
-        { player_id: player.id, gameweek_id: gameweek.id, type: type,
-          value: value.to_f, created_at: now, updated_at: now }
+        record(player, gameweek, type, value.to_f, now)
       end
+    end
+
+    # A rate needs football to have happened. Nought minutes leaves them unwritten
+    # rather than stored as zeroes, so a player with no past reads as unknown.
+    def rates(player, gameweek, season, now)
+      nineties = season["minutes"].to_f / MINUTES_IN_A_MATCH
+      return [] unless nineties.positive?
+
+      RATE_TYPES.filter_map do |type, key|
+        value = season[key]
+        next if value.nil?
+
+        record(player, gameweek, type, value.to_f / nineties, now)
+      end
+    end
+
+    def record(player, gameweek, type, value, now)
+      { player_id: player.id, gameweek_id: gameweek.id, type: type,
+        value: value, created_at: now, updated_at: now }
     end
 
     # history_past runs oldest first, so the most recent season is last.

--- a/app/services/rest_of_season_forecast.rb
+++ b/app/services/rest_of_season_forecast.rb
@@ -28,4 +28,11 @@ class RestOfSeasonForecast < Forecaster
   def model_overrides
     { crowd_weight: CROWD_WEIGHT, new_club_minutes: NEW_CLUB_MINUTES }
   end
+
+  # An injury is a spell out, not the end of a career, so over a season a player
+  # is worth the share of it he is expected to be fit for rather than nothing at
+  # all. See Availability.
+  def fitness(players)
+    Availability.call(players, gameweeks: Gameweek.remaining)
+  end
 end

--- a/app/services/tier_calculator.rb
+++ b/app/services/tier_calculator.rb
@@ -1,6 +1,6 @@
 # Assigns weather-themed tiers to player rankings based on their score
 # relative to the top-ranked player (percentage from top score).
-class TierCalculator
+class TierCalculator < ApplicationService
   TIERS = {
     1 => { symbol: "☀️", name: "Sunshine", description: "Must-start premium picks" },
     2 => { symbol: "🌤️", name: "Partly Cloudy", description: "Strong reliable options" },

--- a/test/services/availability_test.rb
+++ b/test/services/availability_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+
+class AvailabilityTest < ActiveSupport::TestCase
+  setup do
+    Gameweek.destroy_all
+    @team = Team.create!(fpl_id: 900, name: "Test United", short_name: "TUD", code: 900)
+    # Ten weekly gameweeks starting a week from now.
+    @gameweeks = (1..10).map do |week|
+      Gameweek.create!(fpl_id: 900 + week, name: "Gameweek #{900 + week}", start_time: week.weeks.from_now)
+    end
+    @posted = 1.day.ago
+  end
+
+  def player(status:, news: nil, fpl_id: 9100)
+    Player.create!(first_name: "Test", last_name: "Player#{fpl_id}", short_name: "T#{fpl_id}",
+                   fpl_id: fpl_id, code: fpl_id, team: @team, position: "defender",
+                   status: status, news: news, news_added: @posted)
+  end
+
+  def share_for(player)
+    Availability.call([ player ], gameweeks: @gameweeks)[player.id]
+  end
+
+  test "a fit player is left alone, so the model reads FPL's own flag" do
+    assert_empty Availability.call([ player(status: "a") ], gameweeks: @gameweeks)
+  end
+
+  test "a player who has left the league is out for all of it" do
+    gone = player(status: "u", news: "Has joined Grimsby Town on loan for the rest of the season")
+
+    assert_equal 0.0, share_for(gone)
+  end
+
+  test "a named return date counts only the weeks before it" do
+    back = @gameweeks.fourth.start_time.strftime("%-d %b")
+    injured = player(status: "i", news: "Groin injury - Expected back #{back}")
+
+    # Back for the fourth week onwards: seven of the ten.
+    assert_in_delta 0.7, share_for(injured), 0.001
+  end
+
+  test "a suspension is read the same way as an injury" do
+    until_date = @gameweeks.third.start_time.strftime("%-d %b")
+    banned = player(status: "s", news: "Suspended until #{until_date}")
+
+    assert_in_delta 0.8, share_for(banned), 0.001
+  end
+
+  test "over a season, an unknown return date is a long absence and not a permanent one" do
+    injured = player(status: "i", news: "Back injury - Unknown return date")
+    season = @gameweeks + (11..38).map do |week|
+      Gameweek.create!(fpl_id: 900 + week, name: "Gameweek #{900 + week}", start_time: week.weeks.from_now)
+    end
+
+    share = Availability.call([ injured ], gameweeks: season)[injured.id]
+    assert share.positive?, "a player with no return date is still coming back"
+    assert share < 1.0, "and is not treated as fit in the meantime"
+  end
+
+  test "with only a few weeks left, a long absence really does rule a player out" do
+    injured = player(status: "i", news: "Back injury - Unknown return date")
+
+    assert_equal 0.0, share_for(injured), "ten weeks is inside the assumed layoff"
+  end
+
+  test "a doubt costs the coming week and no more" do
+    doubtful = player(status: "d", news: "Knee injury - 75% chance of playing")
+
+    # Nine full weeks plus three quarters of one.
+    assert_in_delta 0.975, share_for(doubtful), 0.001
+  end
+
+  test "a flag still flying long after its return date does not read as fit" do
+    stale = player(status: "i", news: "Knee injury - Expected back 1 Jan")
+    stale.update!(news_added: 2.years.ago)
+
+    assert share_for(stale) < 1.0, "he misses the coming week whatever the date says"
+  end
+
+  test "unparseable news falls back to a long absence rather than raising" do
+    odd = player(status: "i", news: "Injury - Expected back never")
+
+    assert_in_delta share_for(odd), share_for(player(status: "i", news: "Knee injury - Unknown return date",
+                                                    fpl_id: 9101)), 0.001
+  end
+
+  test "with no gameweeks left there is nothing to be available for" do
+    assert_empty Availability.call([ player(status: "i", news: "Knee injury - Unknown return date") ],
+                                   gameweeks: [])
+  end
+end

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -12,15 +12,16 @@ class ExpectedPointsTest < ActiveSupport::TestCase
   # A regular starter with a decent record behind him.
   def regular(minutes: 3000.0, xg: 0.30, xgi: 0.50, clean_sheets: 0.30, owned: 5.0, cost: 60.0)
     {
-      "last_season_minutes" => minutes, "expected_goals_per_90" => xg,
-      "expected_goal_involvements_per_90" => xgi, "clean_sheets_per_90" => clean_sheets,
+      "last_season_minutes" => minutes, "last_season_expected_goals_per_90" => xg,
+      "last_season_expected_goal_involvements_per_90" => xgi,
+      "last_season_clean_sheets_per_90" => clean_sheets,
       "selected_by_percent" => owned, "now_cost" => cost
     }
   end
 
   def forecast(rankings, stats, fixtures: { 1 => [ fixture ] }, managers: nil, movers: [])
-    ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: fixtures,
-                       season_started: false, managers: managers, movers: movers).call
+    ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: fixtures,
+                       season_started: false, managers: managers, movers: movers)
   end
 
   test "expected points is minutes, times what he is worth per 90, times the games ahead" do
@@ -36,8 +37,8 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     stats = { 1 => regular(minutes: 3000.0), 2 => regular(minutes: 900.0) }
 
     # what the pipeline passes pre-season: no gameweeks finished yet
-    result = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
-                                season_started: false, gameweeks_played: 0).call
+    result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                season_started: false, gameweeks_played: 0)
 
     assert_equal 90, result[1][:working][:minutes], "a season of football makes a regular"
     assert result[2][:working][:minutes] < 60,
@@ -108,11 +109,12 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     assert result[2][:points] > result[1][:points], "a season of evidence beats half an hour of luck"
   end
 
-  # A field with a spread of records, so the crowd's ordering has a shape to be
-  # read off. Players 1 and 2 are given identical records in the middle of it.
+  # A field with a spread of records and of prices, so the crowd's ordering has a
+  # shape to be read off and the cheapest tenth is a corner of it rather than most
+  # of it. Players 1 and 2 are given identical records in the middle.
   def crowded_field(owned:, cost:)
     rankings = (1..12).map { |id| ranking(id, position: "forward") }
-    stats = (3..12).to_h { |id| [ id, regular(xg: 0.05 * id, xgi: 0.08 * id, owned: 3.0, cost: 55.0) ] }
+    stats = (3..12).to_h { |id| [ id, regular(xg: 0.05 * id, xgi: 0.08 * id, owned: 3.0, cost: 38.0 + 4 * id) ] }
     stats[1] = regular(xg: 0.3, xgi: 0.45, owned: owned.first, cost: cost.first)
     stats[2] = regular(xg: 0.3, xgi: 0.45, owned: owned.last, cost: cost.last)
     [ rankings, stats ]
@@ -147,14 +149,40 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     assert result[1][:points] < points.first, "but never past the best player we can actually measure"
   end
 
+  # Eight defenders on the four million pound floor with a spread of records, and
+  # four dearer ones above them. Players 1 and 2 have the same thin record; the
+  # game has piled into one of them and ignored the other.
+  def cheap_field
+    rankings = (1..12).map { |id| ranking(id, position: "defender") }
+    stats = (3..8).to_h { |id| [ id, regular(xg: 0.02 * id, xgi: 0.04 * id, owned: 2.0, cost: 40.0) ] }
+    stats.merge!((9..12).to_h { |id| [ id, regular(xg: 0.05 * id, xgi: 0.08 * id, owned: 5.0, cost: 40.0 + 4 * id) ] })
+    stats[1] = regular(xg: 0.01, xgi: 0.02, owned: 25.0, cost: 40.0)
+    stats[2] = regular(xg: 0.01, xgi: 0.02, owned: 0.3, cost: 40.0)
+    [ rankings, stats ]
+  end
+
+  test "among the cheapest, the crowd still says which of them plays" do
+    result = forecast(*cheap_field)
+
+    assert result[1][:points] > result[2][:points],
+           "the same record at the same price, but a quarter of the game owns one of them"
+  end
+
+  test "but backing a cheap player never carries him past what the dear ones are worth" do
+    result = forecast(*cheap_field)
+
+    assert result[1][:points] < result[12][:points],
+           "the best the crowd can say of an enabler is that he is the best of the cheap"
+  end
+
   test "trusting the crowd less pulls a hyped player back toward his own record" do
     rankings, stats = crowded_field(owned: [ 60.0, 3.0 ], cost: [ 90.0, 55.0 ])
     stats[1] = regular(xg: 0.3, xgi: 0.45, owned: 60.0, cost: 90.0) # adored, ordinary record
 
-    full = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
-                              season_started: false, crowd_weight: 1.0).call
-    muted = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
-                               season_started: false, crowd_weight: 0.5).call
+    full = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                              season_started: false, crowd_weight: 1.0)
+    muted = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                               season_started: false, crowd_weight: 0.5)
 
     assert full[1][:working][:crowd] > full[1][:working][:ours],
            "the crowd rates the hyped player above his own record"
@@ -168,12 +196,12 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     rankings = [ ranking(1) ]
     stats = { 1 => regular(minutes: 3000.0) } # a full record, earned at his old club
 
-    capped = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
-                                season_started: false, movers: [ 1 ]).call
-    eased = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
-                               season_started: false, movers: [ 1 ], new_club_minutes: 0.75).call
-    settled = ExpectedPoints.new(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
-                                 season_started: false, movers: []).call
+    capped = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                season_started: false, movers: [ 1 ])
+    eased = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                               season_started: false, movers: [ 1 ], new_club_minutes: 0.75)
+    settled = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: false, movers: [])
 
     assert_equal 45, capped[1][:working][:minutes], "a mover's record argues for half a match"
     assert eased[1][:points] > capped[1][:points], "a longer horizon eases the cap"

--- a/test/services/rest_of_season_forecast_test.rb
+++ b/test/services/rest_of_season_forecast_test.rb
@@ -21,7 +21,9 @@ class RestOfSeasonForecastTest < ActiveSupport::TestCase
     player = Player.create!(first_name: "Test", last_name: "Player#{fpl_id}", short_name: "T#{fpl_id}",
                             fpl_id: fpl_id, code: fpl_id, team: @team, position: "forward")
     {
-      "last_season_minutes" => 3000.0, "season_minutes" => 3000.0, "expected_goals_per_90" => 0.5,
+      "last_season_minutes" => 3000.0, "season_minutes" => 3000.0,
+      "last_season_expected_goals_per_90" => 0.5, "expected_goals_per_90" => 0.5,
+      "last_season_expected_goal_involvements_per_90" => 0.7,
       "expected_goal_involvements_per_90" => 0.7, "selected_by_percent" => 10.0, "now_cost" => 80.0
     }.each { |type, value| Statistic.create!(player: player, gameweek: @next, type: type, value: value) }
     player

--- a/test/services/tier_calculator_test.rb
+++ b/test/services/tier_calculator_test.rb
@@ -6,19 +6,19 @@ class TierCalculatorTest < ActiveSupport::TestCase
   end
 
   test "a single-gameweek score meets the bands directly" do
-    tiers = TierCalculator.new([ ranking(4.5), ranking(2.0) ]).call.map(&:tier)
+    tiers = TierCalculator.call([ ranking(4.5), ranking(2.0) ]).map(&:tier)
     assert_equal [ 1, 4 ], tiers
   end
 
   test "a season total is averaged over its gameweeks before tiering" do
-    without = TierCalculator.new([ ranking(40.0) ]).call.first.tier
-    with = TierCalculator.new([ ranking(40.0) ], points_divisor: 10).call.first.tier
+    without = TierCalculator.call([ ranking(40.0) ]).first.tier
+    with = TierCalculator.call([ ranking(40.0) ], points_divisor: 10).first.tier
 
     assert_equal 1, without, "unaveraged, a season total tops the table"
     assert_equal 2, with, "averaged to 4.0 a game it reads as a strong reliable option"
   end
 
   test "a missing score is snow whatever the divisor" do
-    assert_equal 5, TierCalculator.new([ ranking(nil) ], points_divisor: 10).call.first.tier
+    assert_equal 5, TierCalculator.call([ ranking(nil) ], points_divisor: 10).first.tier
   end
 end

--- a/test/services/weekly_forecast_test.rb
+++ b/test/services/weekly_forecast_test.rb
@@ -16,7 +16,9 @@ class WeeklyForecastTest < ActiveSupport::TestCase
     player = Player.create!(first_name: "Test", last_name: "Player#{fpl_id}", short_name: "T#{fpl_id}",
                             fpl_id: fpl_id, code: fpl_id, team: @team, position: "forward")
     {
-      "last_season_minutes" => 3000.0, "season_minutes" => 3000.0, "expected_goals_per_90" => 0.5,
+      "last_season_minutes" => 3000.0, "season_minutes" => 3000.0,
+      "last_season_expected_goals_per_90" => 0.5, "expected_goals_per_90" => 0.5,
+      "last_season_expected_goal_involvements_per_90" => 0.7,
       "expected_goal_involvements_per_90" => 0.7, "selected_by_percent" => 10.0, "now_cost" => 80.0
     }.each { |type, value| Statistic.create!(player: player, gameweek: @gameweek, type: type, value: value) }
     player


### PR DESCRIPTION
Three signals the model was using outside the range they are valid over, found by asking why Saliba was missing from the rest-of-season page and why Greaves outranked Diop.

## The season

`minutes_played` switched between this season and last on `season_started`, but every scoring rate below it read bootstrap unconditionally. Before a ball is kicked those describe different years.

Greaves has 2205 minutes from Ipswich's last Premier League season and an empty bootstrap record, because he spent last season outside the league. So we modelled him as a nailed-on starter who earns nothing but the two appearance points. 36 players are in that position today, 18 at Ipswich and 8 at Hull.

The larger version of this was about to hit everybody. FPL zeroes the bootstrap season fields before the season starts. When it does, the old code reads nought for every rate, every `points_per_90` collapses to the bare appearance points, and the rankings become a minutes-times-fixtures ordering with no football in them.

Both halves now come from the same season. `SyncPlayerHistories` works the per-90 rates out of `history_past`, which already carries goals, assists, clean sheets, saves and bonus.

| Next gameweek | Before | After |
|---|---|---|
| Davis (IPS) | #69 | **#37** |
| Furlong (IPS) | #82 | #67 |
| O'Shea (IPS) | #70 | #63 |
| Disasi (CHE) | #113 | #96 |

The top of every list is untouched.

## The horizon

`chance_of_playing` is a next-round figure and it multiplied the entire rest-of-season forecast, so "0% chance of playing this Saturday" was read as a verdict on the next nine months. Saliba disappeared from the page entirely.

`Availability` answers the longer question. Where FPL names a return date ("Expected back 21 Aug", "Suspended until 6 Sep") it counts the gameweeks after it. Where it says "Unknown return date" it assumes a long absence rather than a permanent one. A player who has left the league stays at nought, because he really has.

Of 56 flagged players, only 9 carry a date, so the rest is an assumption and the code says so. It stops being an assumption once we have watched these flags clear: we already store fitness week by week.

25 injured players return to the rest-of-season list, including Saliba (#68), Timber (#42) and Ekitiké (#31). Doubtfuls stop paying a permanent quarter for a knock: Grealish #108 to #77.

**The weekly forecast is untouched.** Zeroing an injured man for Saturday is right.

## The peer group

Among the cheapest tenth of a position, the crowd could only ever mark a player down. That kept enablers out of the top, and also made the crowd mute exactly where it knows most, so two £4.0m defenders at the same club could not be told apart by a forty-fold difference in ownership.

The cheap are now ranked against each other. Backing says which of them plays, and the best it can say of one is that he is the best of the cheap.

| Next gameweek | Before | After |
|---|---|---|
| Diop (IPS), 20.5% owned | #101, off the page | **#94, on it** |
| Greaves (IPS), 0.5% owned | #72 | #84 |

## What this does not fix

Greaves is still above Diop. The gap closes from 29 places to 10, and the rest is the minutes term: 83 projected minutes against 31, because Greaves has a full season on record and Diop has 812 minutes at his old club.

The real answer is that **ownership is evidence about minutes, not about points**. A fifth of the game owning a £4.0m defender is the crowd saying he starts every week, and we feed that into the points blend where it argues about quality instead. Worth thinking through separately.

## Deploying

Self-backfilling. The receipt that records "we asked FPL about this player" now carries a version, so the next hourly run refetches all 564 in its usual batches. No rake task, no manual step. It took 90 seconds locally.

## Notes

- 170 tests, RuboCop clean
- Every before/after figure above was measured against a fixed snapshot of the data, both sides in the same state
- `ConsensusRanking`, `TierCalculator` and `ExpectedPoints` now inherit `ApplicationService` instead of spelling out what it already does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJM9XstRaYZz5N7RYyxaP