### PR TITLE
Mark a week against the week's forecast, not the season's

### DIFF
--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -16,6 +16,11 @@ class Forecast < ApplicationRecord
   scope :by_rank, -> { order(rank: :asc) }
   scope :by_week, ->(week) { joins(:gameweek).where(gameweeks: { fpl_id: week }) }
 
+  # What a player was expected to score in that week alone. A rest-of-season
+  # forecast is stored against the same gameweek, so anything asking "what did we
+  # say about this week" has to say which of the two it means.
+  scope :weekly, -> { where(horizon: "gameweek") }
+
   private
 
   def assign_next_gameweek!

--- a/app/services/forecast_accuracy.rb
+++ b/app/services/forecast_accuracy.rb
@@ -134,8 +134,21 @@ class ForecastAccuracy < ApplicationService
     forecasts.select { |id, _| positions[id] == position }.keys
   end
 
+  # The week's own forecast, and only that one.
+  #
+  # A gameweek carries two forecasts per player: what he was expected to score
+  # that week, and what he was expected to score across the rest of the season,
+  # which is anchored to the same week. Reading both and building a hash from
+  # them keeps whichever came back last, so a player we had put at 4.8 points was
+  # marked as though we had said 172.5. It would not have failed. It would have
+  # quietly returned a plausible number for the wrong forecast, which is the only
+  # kind of bug an accuracy measure cannot survive.
+  #
+  # Marking a season total against one week's points is a fair question but a
+  # different one, and it needs its own measure: a capture rate wants both sides
+  # talking about the same football.
   def forecasts
-    @forecasts ||= Forecast.where(gameweek: @gameweek).pluck(:player_id, :score).to_h
+    @forecasts ||= Forecast.weekly.where(gameweek: @gameweek).pluck(:player_id, :score).to_h
   end
 
   def positions

--- a/test/services/forecast_accuracy_test.rb
+++ b/test/services/forecast_accuracy_test.rb
@@ -29,6 +29,21 @@ class ForecastAccuracyTest < ActiveSupport::TestCase
     assert_equal 1.0, result["forward"][:correlation]
   end
 
+  test "the week is marked against the week's forecast, not the season's" do
+    players = field((1..20).to_a.reverse) # our weekly order is exactly the scoring order
+    # The same week also carries a rest-of-season forecast: season-sized numbers,
+    # and deliberately the opposite order.
+    players.each_with_index do |player, index|
+      Forecast.create!(player: player, gameweek: @gameweek, rank: index + 1,
+                       score: (index + 1) * 10.0, horizon: "rest_of_season")
+    end
+
+    result = ForecastAccuracy.call(gameweek: @gameweek)
+
+    assert_equal 100.0, result["forward"][:capture_rate], "the week's own forecast is what gets marked"
+    assert_in_delta 10.5, result["forward"][:predicted], 0.1, "in the week's own numbers, not a season total"
+  end
+
   test "a backwards forecast captures the least it could" do
     field((1..20).to_a) # our best pick scored least
 


### PR DESCRIPTION
Found while explaining how the accuracy check works, before ever running it.

## The bug

Since the rest-of-season horizon arrived, a gameweek carries **two** forecasts per player: the week's own, and the rest-of-season one anchored to the same week. `ForecastAccuracy` read both:

```ruby
Forecast.where(gameweek: @gameweek).pluck(:player_id, :score).to_h
```

1,128 rows for 564 players, and `to_h` silently keeps whichever came back last. On today's data the first player is predicted 4.8 points for the week and 172.5 for the season, and the season figure is what would have been marked.

It would not have raised. It would have returned a plausible-looking capture rate for the wrong forecast, and since nothing has ever been marked before, there is no previous figure to notice it against. That is the one kind of bug an accuracy measure cannot survive: the number exists to tell us whether to trust the model, so a quietly wrong one is worse than none.

## The fix

A `weekly` scope on `Forecast`, so anything asking "what did we say about this week" has to say which of the two it means.

Marking a season total against a single week's points is a fair question, but a different one needing its own measure, and the comment says so rather than leaving the next person to wonder.

## The test

A perfect weekly forecast, with a deliberately backwards season-long forecast stored against the same week, still marks 100% and reports the week's own numbers. Verified it fails without the fix rather than passing either way.

171 tests, RuboCop clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJM9XstRaYZz5N7RYyxaP