### PR TITLE
Rank on the forecast, shrink bonus with the record, and date the page

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -47,6 +47,7 @@ class PlayersController < ApplicationController
     load_row_facts
     build_shortlist
     load_gameweek_data
+    load_forecast_time
     load_players
     set_available_filters
     build_page_title
@@ -157,6 +158,13 @@ class PlayersController < ApplicationController
   # bands a single week does.
   def tier_divisor
     rest_of_season? ? [ Gameweek.remaining.count, 1 ].max : 1
+  end
+
+  # When the numbers on the page were worked out. They are rewritten on the hour
+  # as FPL's own data moves, and a transfer can shift a player a dozen places
+  # between one reading and the next, so the page says which reading this is.
+  def load_forecast_time
+    @forecast_at = Forecast.where(gameweek: @gameweek_record, horizon: @horizon).maximum(:updated_at)
   end
 
   def load_gameweek_data

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -212,7 +212,7 @@ class ExpectedPoints < ApplicationService
     return { points: nil, working: {} } if ours.nil? && theirs.nil?
 
     points = blended(ranking, ours, theirs) * availability(ranking) * games_ahead(ranking) * transfer_factor(ranking)
-    { points: points.round(1), working: working_for(ranking, ours, theirs) }
+    { points: points, working: working_for(ranking, ours, theirs) }
   end
 
   # What a player is worth in a single game, before the fixture and before this

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -388,11 +388,18 @@ class ExpectedPoints < ApplicationService
 
   # Bonus is awarded per match to the three best performers, so it is not in any
   # per-90 rate FPL publishes and has to be worked out from his own totals.
+  #
+  # Dividing by the minutes he actually played would undo the doubt the rest of
+  # the model carries: a rate that grows as the minutes shrink, multiplied by a
+  # credibility that shrinks with them, cancels to a fixed share of his bonus
+  # however little football it came from. So a short record is read against the
+  # five matches of doubt instead, and one bonus point off the bench stays worth
+  # about what it was.
   def bonus_points(ranking)
     played = minutes_played(ranking).to_f
     return 0.0 if played.zero?
 
-    record(ranking, "season_bonus") / (played / FULL_MATCH)
+    record(ranking, "season_bonus") / ([ played, UNPROVEN_MINUTES ].max / FULL_MATCH)
   end
 
   # Nought before a ball is kicked, and nought for a player with no record, both of

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -6,6 +6,12 @@
     <div class="mb-6">
       <h1 class="text-xl sm:text-2xl font-semibold text-zinc-900"><%= @page_title %></h1>
       <p class="mt-1 text-sm text-zinc-500">Form, fixtures, and expected goals analyzed into weather tiers.</p>
+      <% if @forecast_at %>
+        <p class="mt-1 text-xs text-zinc-400">
+          Updated
+          <time datetime="<%= @forecast_at.iso8601 %>" title="<%= l @forecast_at, format: :long %>"><%= time_ago_in_words(@forecast_at) %> ago</time>
+        </p>
+      <% end %>
     </div>
 
     <div class="flex flex-wrap items-center gap-4 mb-6">

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -49,6 +49,15 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "says when the forecast on the page was worked out" do
+    forecast = Forecast.create!(player: @player, gameweek: @gameweek5, rank: 1, score: 4.2)
+    forecast.update_column(:updated_at, 3.hours.ago)
+
+    get gameweek_position_path(gameweek: 5, position: "#{@player.position}s")
+
+    assert_select "time", text: "about 3 hours ago"
+  end
+
   test "should show forecasts data when available" do
     Forecast.create!(player: @player, gameweek: @gameweek5, rank: 1, score: 4.2)
     Forecast.create!(player: @player2, gameweek: @gameweek5, rank: 2, score: 3.1)

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -45,6 +45,17 @@ class ExpectedPointsTest < ActiveSupport::TestCase
            "a bit-part player is not a regular just because no gameweek has finished yet"
   end
 
+  test "a hair between two players is not rounded into a tie" do
+    rankings = [ ranking(1), ranking(2) ]
+    stats = { 1 => regular(xgi: 0.500), 2 => regular(xgi: 0.503) }
+
+    result = forecast(rankings, stats)
+
+    assert_in_delta result[1][:points], result[2][:points], 0.05, "the two are all but level"
+    assert result[2][:points] > result[1][:points],
+           "and the better of them still ranks first: the order is settled by the forecast, not by rounding"
+  end
+
   test "a player who does not play scores nothing, however good he is" do
     elite = regular(xg: 1.0, xgi: 1.4)
     rankings = [ ranking(1), ranking(2) ]

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -56,6 +56,29 @@ class ExpectedPointsTest < ActiveSupport::TestCase
            "and the better of them still ranks first: the order is settled by the forecast, not by rounding"
   end
 
+  # What a player's bonus is worth to him, measured against the same player
+  # without it. Two gameweeks in, so a full match is a real share of the football
+  # played so far.
+  def bonus_gain(minutes, bonus)
+    played = { "expected_goals_per_90" => 0.30, "expected_goal_involvements_per_90" => 0.50,
+               "clean_sheets_per_90" => 0.30, "selected_by_percent" => 5.0,
+               "now_cost" => 60.0, "season_minutes" => minutes }
+    stats = { 1 => played.merge("season_bonus" => bonus), 2 => played.merge("season_bonus" => 0.0) }
+
+    result = ExpectedPoints.call([ ranking(1), ranking(2) ], stats: stats,
+                                fixtures_by_team: { 1 => [ fixture ] },
+                                season_started: true, gameweeks_played: 2)
+    result[1][:points] - result[2][:points]
+  end
+
+  test "bonus counts for less when there is less football behind it" do
+    cameo = bonus_gain(45.0, 6.0)
+    regular = bonus_gain(200.0, 3.0)
+
+    assert cameo < regular / 2,
+           "twice the bonus from a fifth of the football cannot be worth as much as the record"
+  end
+
   test "a player who does not play scores nothing, however good he is" do
     elite = regular(xg: 1.0, xgi: 1.4)
     rankings = [ ranking(1), ranking(2) ]


### PR DESCRIPTION
Three fixes from the ranking review, one per commit.

### Rank on the forecast, not on the rounding

Every forecast was rounded to a tenth before anything read it, and the order is decided by that rounded figure. Two players a thousandth apart became tied, and `Forecaster#ordered` settled the tie on `short_name`, so the rankings fell back on the alphabet. Among five defenders level at 3.5, the true order was Kayode, Konsa, Cash, Ballard, Kerkez and the stored one was almost its reverse. The defender list alone had 27 such ties.

`score` is `numeric(10,4)` and nothing on the page prints the raw number, so there was nothing to round for. The name stays as the last resort for a genuine dead heat.

### Read bonus against the doubt the rest of the model carries

Bonus is worked out from a player's own totals rather than read as a rate, so dividing by the minutes he played made it grow as his record shrank. Credibility then shrank it back by the same minutes and the two cancelled: however little football it came from, a player kept a fixed fifth of his bonus.

Measured before the fix: six bonus points from 45 minutes were worth **0.390** of a forecast against **0.415** for three from 200 minutes, near enough the same credit for a fifth of the evidence. After: **0.039** against **0.185**.

Latent rather than live, since no player in the current data combines a thin record with a bonus total, but it fires the first time a fringe player earns a bonus point off the bench.

### Say when the rankings were worked out

While reviewing the rankings a sync moved Lacroix from Palace to Chelsea and took him from 9th to 24th, with nothing on the page to say the ground had shifted. The page now carries the time its numbers were worked out, relative for reading and exact in the tooltip.

---

173 tests, 0 failures. Both scoring fixes have a test that fails without the change and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcEXK6XpvnLXMHoUuywLeo