### PR TITLE
Let a signing's backing say whether he has walked into the side

### DIFF
--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -65,6 +65,26 @@ class ExpectedPoints < ApplicationService
   # rest-of-season horizon lifts the cap so his record does more of the talking.
   NEW_CLUB_MINUTES = 0.5
 
+  # How much of the game has to own a new signing before we take it that he has
+  # walked into the side.
+  #
+  # The cap above is an admission that we do not know whether he starts, and that
+  # is the one question the crowd answers better than any record can: managers do
+  # not spend a squad place on a man who sits out. So where we have said "his
+  # minutes belong to another club's team sheet", their money is allowed to say
+  # "and he is first choice at this one".
+  #
+  # It is deliberately the narrowest use we could make of ownership. It applies
+  # only where we have already confessed to guessing, it can only lift a player
+  # and never mark him down, and it stops at a regular's share: backing may
+  # establish that a man plays, never that he is any good, which is what his
+  # record is for.
+  #
+  # A tenth of the game is a lot of managers when the average player is owned by
+  # two per cent of it. A starting figure, to be settled by what actually happens
+  # to these players' minutes.
+  NAILED_ON = 10.0
+
   # FPL's scoring table, by position.
   GOAL = { "goalkeeper" => 10, "defender" => 6, "midfielder" => 5, "forward" => 4 }.freeze
   CLEAN_SHEET = { "goalkeeper" => 4, "defender" => 4, "midfielder" => 1, "forward" => 0 }.freeze
@@ -167,7 +187,7 @@ class ExpectedPoints < ApplicationService
       form_swing: FORM_SWING, fixture_swing: FIXTURE_SWING,
       crowd_share_min: CROWD_SHARE_MIN, crowd_share_max: CROWD_SHARE_MAX,
       crowd_weight: CROWD_WEIGHT, price_power: PRICE_POWER,
-      new_club_minutes: NEW_CLUB_MINUTES, cheapest: CHEAPEST,
+      new_club_minutes: NEW_CLUB_MINUTES, nailed_on: NAILED_ON, cheapest: CHEAPEST,
       exodus_floor: EXODUS_FLOOR, inflow_ceiling: INFLOW_CEILING
     }
   end
@@ -338,7 +358,14 @@ class ExpectedPoints < ApplicationService
     return nil if played.nil?
 
     regular = [ played / regular_minutes, 1.0 ].min
-    @movers.include?(ranking.player_id) ? [ regular, @new_club_minutes ].min : regular
+    return regular unless @movers.include?(ranking.player_id)
+
+    [ [ regular, @new_club_minutes ].min, settled_in(ranking) ].max
+  end
+
+  # What a signing's backing says about the team sheet. See NAILED_ON.
+  def settled_in(ranking)
+    REGULAR_SHARE * (ownership(ranking) / NAILED_ON).clamp(0.0, 1.0)
   end
 
   def minutes_played(ranking)

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -208,6 +208,45 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     assert eased[1][:points] < settled[1][:points], "but not all the way to a settled regular"
   end
 
+  # Two signings with the same thin record at their old clubs. The only thing
+  # separating them is how much of the game has already picked them.
+  def two_signings(owned:)
+    rankings = [ ranking(1), ranking(2) ]
+    stats = { 1 => regular(minutes: 800.0, owned: owned.first),
+              2 => regular(minutes: 800.0, owned: owned.last) }
+    [ rankings, stats ]
+  end
+
+  test "a signing the game has picked is taken to have walked into the side" do
+    rankings, stats = two_signings(owned: [ 20.0, 0.4 ])
+
+    result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: false, movers: [ 1, 2 ])
+
+    assert_equal 63, result[1][:working][:minutes], "a fifth of the game owning him settles it"
+    assert_equal 30, result[2][:working][:minutes], "and nobody owning him leaves the caution in place"
+  end
+
+  test "backing can establish that a signing plays, never that he is any good" do
+    rankings = [ ranking(1) ]
+    stats = { 1 => regular(minutes: 3000.0, owned: 90.0) } # adored, and a full record elsewhere
+
+    result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: false, movers: [ 1 ])
+
+    assert_equal 63, result[1][:working][:minutes], "it stops at a regular's share, not a full match"
+  end
+
+  test "a settled player's minutes are his own business, however many own him" do
+    rankings, stats = two_signings(owned: [ 40.0, 0.4 ])
+
+    result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: false, movers: [])
+
+    assert_equal result[2][:working][:minutes], result[1][:working][:minutes],
+                 "ownership only answers the question the new-club cap asks"
+  end
+
   test "a rush for the exit drops a player hard and at once" do
     rankings = [ ranking(1), ranking(2) ]
     owned = regular(owned: 10.0) # a tenth of 10m managers, so a million owners


### PR DESCRIPTION
The last piece of the Greaves and Diop puzzle, and the principled home for ownership.

## The idea

A player who has just changed clubs has a minutes record belonging to somebody else's team sheet, so `NEW_CLUB_MINUTES` holds it to half a match. That cap is an **admission that we do not know whether he starts**, and it is the one question the crowd answers better than any record can: managers do not spend a squad place on a man who sits out.

So where we have already said "his minutes belong to another club", their money is now allowed to say "and he is first choice at this one". A tenth of the game owning him settles it, which is a lot of managers when the average player is owned by about two per cent.

This is deliberately the narrowest use of ownership available:

- it applies **only where we had already confessed to guessing**
- it can only **lift** a player, never mark him down
- it stops at a regular's share, so backing may establish that a man plays, never that he is any good, which is what his record is for

## Effect

| Next gameweek | Before | After |
|---|---|---|
| **Diop** (IPS) | #94, 1.5 | **#70, 2.3** |
| Rogers (CHE) | #14 | #10 |
| Dubravka (TOT) | #19 | #17 |

Diop was the case that started this. A fifth of the game owns him, he is plainly Ipswich's centre-back, and we had him down for thirty-one minutes because his 812 minutes were earned at Fulham. Over the rest of the season he moves #105 to #78.

Seven players move ten places or more in the weekly rankings and four over the season. Nothing else stirs.

## The version I did not build

I prototyped the broader idea first, where ownership informs **everyone's** minutes rather than a signing's, and measured both against a fixed snapshot of the data:

| | Base | All players | Signings only |
|---|---|---|---|
| Diop | #94 (1.5) | #70 (2.3) | #70 (2.3) |
| Kinsky (GK) | #18 | #15 | #19, untouched |
| Move 10+ places | | 7 | 4 |
| Newly shown | | 30 | 5 |

The broad version gains **nothing** on the case that prompted it, reaches players whose own record already answers the question, and lifts a Spurs goalkeeper into a list that then holds three of them. It is also a much larger claim: that ownership predicts minutes generally, rather than resolving one specific unknown.

Bench fodder is the reason to be careful. A cheap second keeper is owned precisely *because* he does not play: you need two and one sits. The narrow version is far less exposed to that.

If we want the broad version later, GW1 to GW3 will give real minutes to fit it against, and the accuracy harness can score it. Better than fitting it to my judgement in August.

## Notes

- 173 tests, RuboCop clean
- `NAILED_ON` joins `ExpectedPoints.parameters`, so every forecast records the dial that produced it and a future comparison can tell the versions apart
- Every figure measured with both sides against identical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJM9XstRaYZz5N7RYyxaP