### PR TITLE
Give the season a page of its own, and one name

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -16,7 +16,7 @@ class PlayersController < ApplicationController
 
   before_action :set_filters, only: [ :index ]
 
-  helper_method :rest_of_season?, :horizon_label, :horizon_short, :horizon_param
+  helper_method :season?, :horizon_label, :horizon_short, :horizon_param
 
   def index
     return if redirect_to_clean_url
@@ -120,11 +120,11 @@ class PlayersController < ApplicationController
     @team_filter = params[:team_id].present? ? params[:team_id].to_i : nil
   end
 
-  # Rest of season is anchored to the next gameweek: its rows are stored against
-  # that week, and validation and titling resolve a real gameweek from it.
+  # The season horizon is anchored to the next gameweek: its rows are stored
+  # against that week, and validation and titling resolve a real gameweek from it.
   def set_horizon
     if params[:gameweek] == REST_OF_SEASON
-      @horizon = "rest_of_season"
+      @horizon = "season"
       @gameweek = next_gameweek&.fpl_id
     else
       @horizon = "gameweek"
@@ -132,8 +132,8 @@ class PlayersController < ApplicationController
     end
   end
 
-  def rest_of_season?
-    @horizon == "rest_of_season"
+  def season?
+    @horizon == "season"
   end
 
   def resolve_position(param)
@@ -157,7 +157,7 @@ class PlayersController < ApplicationController
   # A season total is read as its per-gameweek average, so it meets the same tier
   # bands a single week does.
   def tier_divisor
-    rest_of_season? ? [ Gameweek.remaining.count, 1 ].max : 1
+    season? ? [ Gameweek.remaining.count, 1 ].max : 1
   end
 
   # When the numbers on the page were worked out. They are rewritten on the hour
@@ -243,15 +243,15 @@ class PlayersController < ApplicationController
   end
 
   def horizon_param
-    rest_of_season? ? REST_OF_SEASON : @gameweek
+    season? ? REST_OF_SEASON : @gameweek
   end
 
   def horizon_label
-    rest_of_season? ? "Rest of Season" : "Gameweek #{@gameweek}"
+    season? ? "Rest of Season" : "Gameweek #{@gameweek}"
   end
 
   def horizon_short
-    rest_of_season? ? "Rest of Season" : "GW#{@gameweek}"
+    season? ? "Rest of Season" : "GW#{@gameweek}"
   end
 
   def build_page_title

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -9,6 +9,10 @@ class PlayersController < ApplicationController
     "goalkeeper" => 50, "defender" => 100, "midfielder" => 100, "forward" => 50
   }.freeze
 
+  # The horizon that spans every gameweek that remains, as the routes and the
+  # stored forecasts both spell it.
+  SEASON = "season".freeze
+
   POSITION_SINGULARS = {
     "goalkeepers" => "goalkeeper", "defenders" => "defender",
     "midfielders" => "midfielder", "forwards" => "forward"
@@ -16,7 +20,7 @@ class PlayersController < ApplicationController
 
   before_action :set_filters, only: [ :index ]
 
-  helper_method :season?, :horizon_label, :horizon_short, :horizon_param
+  helper_method :season?, :horizon_label, :horizon_short, :horizon_param, :rankings_path
 
   def index
     return if redirect_to_clean_url
@@ -107,12 +111,19 @@ class PlayersController < ApplicationController
   end
 
   def build_clean_url
-    position = resolve_position(params[:position])
-    extra = params.permit(:team_id).to_h.compact_blank
-    gameweek_position_path(gameweek: params[:gameweek], position: "#{position}s", **extra)
+    rankings_path(params[:gameweek], resolve_position(params[:position]),
+                  **params.permit(:team_id).to_h.compact_blank.symbolize_keys)
   end
 
-  REST_OF_SEASON = "ros".freeze
+  # Where a horizon lives. The season has a page of its own; a week is named by
+  # its number.
+  def rankings_path(horizon, position, **extra)
+    if horizon == SEASON
+      season_position_path(position: "#{position}s", **extra)
+    else
+      gameweek_position_path(gameweek: horizon, position: "#{position}s", **extra)
+    end
+  end
 
   def set_filters
     set_horizon
@@ -123,8 +134,8 @@ class PlayersController < ApplicationController
   # The season horizon is anchored to the next gameweek: its rows are stored
   # against that week, and validation and titling resolve a real gameweek from it.
   def set_horizon
-    if params[:gameweek] == REST_OF_SEASON
-      @horizon = "season"
+    if season_requested?
+      @horizon = SEASON
       @gameweek = next_gameweek&.fpl_id
     else
       @horizon = "gameweek"
@@ -132,8 +143,14 @@ class PlayersController < ApplicationController
     end
   end
 
+  # The season page says so in its route; the horizon dropdown says so in the
+  # parameter it submits, on its way to that page.
+  def season_requested?
+    params[:horizon] == SEASON || params[:gameweek] == SEASON
+  end
+
   def season?
-    @horizon == "season"
+    @horizon == SEASON
   end
 
   def resolve_position(param)
@@ -238,12 +255,12 @@ class PlayersController < ApplicationController
   def horizon_options
     options = []
     options << [ "Next Gameweek", next_gameweek.fpl_id ] if next_gameweek
-    options << [ "Rest of Season", REST_OF_SEASON ]
+    options << [ "Rest of Season", SEASON ]
     options
   end
 
   def horizon_param
-    season? ? REST_OF_SEASON : @gameweek
+    season? ? SEASON : @gameweek
   end
 
   def horizon_label
@@ -258,7 +275,7 @@ class PlayersController < ApplicationController
     @page_title = "Player Rankings - #{horizon_label}"
     @page_title += " #{@position_filter.capitalize}s" if @position_filter.present?
     @page_title += " - #{Team.find_by(id: @team_filter)&.name}" if @team_filter
-    @canonical_path = gameweek_position_path(gameweek: horizon_param, position: "#{@position_filter}s")
+    @canonical_path = rankings_path(horizon_param, @position_filter)
   end
 
   def next_gameweek

--- a/app/services/fpl/hourly_pipeline.rb
+++ b/app/services/fpl/hourly_pipeline.rb
@@ -35,7 +35,7 @@ module Fpl
       return Rails.logger.info("No next gameweek, skipping forecast generation.") unless gameweek
 
       WeeklyForecast.call(gameweek: gameweek)
-      RestOfSeasonForecast.call(gameweek: gameweek)
+      SeasonForecast.call(gameweek: gameweek)
     end
   end
 end

--- a/app/services/season_forecast.rb
+++ b/app/services/season_forecast.rb
@@ -6,7 +6,7 @@
 # This is a naive season total. The transfer, form and availability signals are
 # today's snapshot applied the whole way out, which is honest for the next
 # gameweek and progressively less so the further ahead you read.
-class RestOfSeasonForecast < Forecaster
+class SeasonForecast < Forecaster
   # The crowd's order is an early-season reading, so over a whole season it is
   # trusted less and each player's own record does more of the talking.
   CROWD_WEIGHT = 0.85
@@ -18,7 +18,7 @@ class RestOfSeasonForecast < Forecaster
   private
 
   def horizon
-    "rest_of_season"
+    "season"
   end
 
   def matches

--- a/app/views/players/_seo_content.html.erb
+++ b/app/views/players/_seo_content.html.erb
@@ -109,7 +109,7 @@
         Browse rankings for other positions:
         <% other_positions.each_with_index do |pos, i| %>
           <%= link_to "#{pos.capitalize}s",
-              gameweek_position_path(gameweek: horizon_param, position: "#{pos}s"),
+              rankings_path(horizon_param, pos),
               class: "text-blue-600 hover:underline",
               data: { turbo_frame: "_top" } %><%= i == other_positions.size - 1 ? "." : "," %>
         <% end %>

--- a/app/views/shared/sitemap.xml.erb
+++ b/app/views/shared/sitemap.xml.erb
@@ -7,6 +7,15 @@
     <priority>1.0</priority>
   </url>
 
+  <!-- Season Rankings Pages: the one ranking URL that is good all year -->
+  <% %w[forwards midfielders defenders goalkeepers].each do |position| %>
+  <url>
+    <loc><%= @base_url %><%= season_position_path(position: position) %></loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <% end %>
+
   <!-- Gameweek + Position Rankings Pages -->
   <% @gameweeks_with_forecasts.each do |gw| %>
     <% %w[forwards midfielders defenders goalkeepers].each do |position| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,19 @@
 Rails.application.routes.draw do
   root "players#index"
 
-  # SEO-friendly forecast URLs
+  POSITIONS = /goalkeepers|defenders|midfielders|forwards/
+
+  # SEO-friendly forecast URLs. Two horizons: all the football that remains, or
+  # one week of it.
+  get "season/:position", to: "players#index", as: :season_position,
+      defaults: { horizon: "season" }, constraints: { position: POSITIONS }
+
   get "gameweeks/:gameweek/:position", to: "players#index", as: :gameweek_position,
-      constraints: { gameweek: /\d+|ros/, position: /goalkeepers|defenders|midfielders|forwards/ }
+      constraints: { gameweek: /\d+/, position: POSITIONS }
+
+  # The season used to be spelled as though it were a gameweek.
+  get "gameweeks/ros/:position", to: redirect("/season/%{position}", status: 301),
+      constraints: { position: POSITIONS }
 
   # Redirect old /players path to root
   get "players", to: redirect("/", status: 301)

--- a/db/migrate/20260802220000_rename_rest_of_season_horizon_to_season.rb
+++ b/db/migrate/20260802220000_rename_rest_of_season_horizon_to_season.rb
@@ -1,0 +1,9 @@
+class RenameRestOfSeasonHorizonToSeason < ActiveRecord::Migration[8.1]
+  def up
+    execute "UPDATE forecasts SET horizon = 'season' WHERE horizon = 'rest_of_season'"
+  end
+
+  def down
+    execute "UPDATE forecasts SET horizon = 'rest_of_season' WHERE horizon = 'season'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_220000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -132,7 +132,7 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "rest of season route shows rest-of-season forecasts" do
-    Forecast.create!(player: @player, gameweek: @gameweek2, rank: 1, score: 40.0, horizon: "rest_of_season")
+    Forecast.create!(player: @player, gameweek: @gameweek2, rank: 1, score: 40.0, horizon: "season")
 
     get gameweek_position_path(gameweek: "ros", position: "#{@player.position}s")
     assert_response :success

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -131,14 +131,33 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name=gameweek] option", text: "5", count: 0
   end
 
-  test "rest of season route shows rest-of-season forecasts" do
+  test "the season route shows season forecasts" do
     Forecast.create!(player: @player, gameweek: @gameweek2, rank: 1, score: 40.0, horizon: "season")
 
-    get gameweek_position_path(gameweek: "ros", position: "#{@player.position}s")
+    get season_position_path(position: "#{@player.position}s")
     assert_response :success
     assert_includes response.body, @player.short_name
     assert_includes response.body, "Rest of Season"
     assert_select "select[name=gameweek] option[selected]", text: "Rest of Season"
+  end
+
+  test "the season page the horizon dropdown asks for is the season page" do
+    get root_path(gameweek: "season", position: "#{@player.position}s")
+
+    assert_redirected_to season_position_path(position: "#{@player.position}s")
+  end
+
+  test "the season used to be spelled as a gameweek, and that link still works" do
+    get "/gameweeks/ros/#{@player.position}s"
+
+    assert_response :moved_permanently
+    assert_redirected_to season_position_path(position: "#{@player.position}s")
+  end
+
+  test "a team filter survives the trip to the season page" do
+    get root_path(gameweek: "season", position: "#{@player.position}s", team_id: @test_team.id)
+
+    assert_redirected_to season_position_path(position: "#{@player.position}s", team_id: @test_team.id)
   end
 
   test "the horizon selector offers next gameweek and rest of season" do
@@ -147,10 +166,10 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name=gameweek] option", text: "Rest of Season"
   end
 
-  test "a weekly forecast is not shown under the rest-of-season horizon" do
+  test "a weekly forecast is not shown under the season horizon" do
     Forecast.create!(player: @player, gameweek: @gameweek2, rank: 1, score: 4.0, horizon: "gameweek")
 
-    get gameweek_position_path(gameweek: "ros", position: "#{@player.position}s")
+    get season_position_path(position: "#{@player.position}s")
     assert_response :success
     assert_not_includes response.body, @player.short_name
   end

--- a/test/services/forecast_accuracy_test.rb
+++ b/test/services/forecast_accuracy_test.rb
@@ -35,7 +35,7 @@ class ForecastAccuracyTest < ActiveSupport::TestCase
     # and deliberately the opposite order.
     players.each_with_index do |player, index|
       Forecast.create!(player: player, gameweek: @gameweek, rank: index + 1,
-                       score: (index + 1) * 10.0, horizon: "rest_of_season")
+                       score: (index + 1) * 10.0, horizon: "season")
     end
 
     result = ForecastAccuracy.call(gameweek: @gameweek)

--- a/test/services/season_forecast_test.rb
+++ b/test/services/season_forecast_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RestOfSeasonForecastTest < ActiveSupport::TestCase
+class SeasonForecastTest < ActiveSupport::TestCase
   setup do
     Forecast.destroy_all
     Strategy.destroy_all
@@ -30,9 +30,9 @@ class RestOfSeasonForecastTest < ActiveSupport::TestCase
   end
 
   test "writes a rest-of-season forecast anchored to the next gameweek" do
-    RestOfSeasonForecast.call(gameweek: @next)
+    SeasonForecast.call(gameweek: @next)
 
-    forecast = Forecast.find_by(player: @player, horizon: "rest_of_season")
+    forecast = Forecast.find_by(player: @player, horizon: "season")
     assert_equal @next.id, forecast.gameweek_id, "the season total is anchored to the next gameweek"
     assert forecast.score.to_f.positive?
     assert_equal 1, forecast.rank
@@ -40,20 +40,20 @@ class RestOfSeasonForecastTest < ActiveSupport::TestCase
 
   test "spans every remaining gameweek, so it outscores the single coming week" do
     WeeklyForecast.call(gameweek: @next)
-    RestOfSeasonForecast.call(gameweek: @next)
+    SeasonForecast.call(gameweek: @next)
 
     weekly = Forecast.find_by(player: @player, horizon: "gameweek").score
-    season = Forecast.find_by(player: @player, horizon: "rest_of_season").score
+    season = Forecast.find_by(player: @player, horizon: "season").score
 
     assert_operator season, :>, weekly, "two games ahead is worth more than one"
   end
 
   test "the two horizons sit side by side against the same gameweek" do
     WeeklyForecast.call(gameweek: @next)
-    RestOfSeasonForecast.call(gameweek: @next)
+    SeasonForecast.call(gameweek: @next)
 
     horizons = Forecast.where(player: @player, gameweek: @next).pluck(:horizon).sort
-    assert_equal %w[gameweek rest_of_season], horizons
+    assert_equal %w[gameweek season], horizons
   end
 
   test "excludes gameweeks already finished from the horizon" do
@@ -65,31 +65,31 @@ class RestOfSeasonForecastTest < ActiveSupport::TestCase
 
   test "records that it trusted the crowd less than the weekly forecast" do
     WeeklyForecast.call(gameweek: @next)
-    RestOfSeasonForecast.call(gameweek: @next)
+    SeasonForecast.call(gameweek: @next)
 
     weekly = Forecast.find_by(horizon: "gameweek").strategy.strategy_config[:crowd_weight]
-    season = Forecast.find_by(horizon: "rest_of_season").strategy.strategy_config[:crowd_weight]
+    season = Forecast.find_by(horizon: "season").strategy.strategy_config[:crowd_weight]
 
     assert_equal 1.0, weekly
-    assert_equal RestOfSeasonForecast::CROWD_WEIGHT, season
+    assert_equal SeasonForecast::CROWD_WEIGHT, season
     assert_operator season, :<, weekly, "a season out trusts the early-season crowd less"
   end
 
   test "records that it eased the new-club cap for the season horizon" do
     WeeklyForecast.call(gameweek: @next)
-    RestOfSeasonForecast.call(gameweek: @next)
+    SeasonForecast.call(gameweek: @next)
 
     weekly = Forecast.find_by(horizon: "gameweek").strategy.strategy_config[:new_club_minutes]
-    season = Forecast.find_by(horizon: "rest_of_season").strategy.strategy_config[:new_club_minutes]
+    season = Forecast.find_by(horizon: "season").strategy.strategy_config[:new_club_minutes]
 
-    assert_equal RestOfSeasonForecast::NEW_CLUB_MINUTES, season
+    assert_equal SeasonForecast::NEW_CLUB_MINUTES, season
     assert_operator season, :>, weekly, "a settled signing is trusted more over a whole season"
   end
 
   test "refuses to write a position it cannot score anybody in" do
     Match.destroy_all
 
-    assert_not RestOfSeasonForecast.call(gameweek: @next)
-    assert_equal 0, Forecast.where(horizon: "rest_of_season").count
+    assert_not SeasonForecast.call(gameweek: @next)
+    assert_equal 0, Forecast.where(horizon: "season").count
   end
 end


### PR DESCRIPTION
Two commits: the rename, then the routing.

### Call the season horizon the season

The same horizon answered to four names: `ros` in a URL, `rest_of_season` in the column and the class, `REST_OF_SEASON` in a constant, and "Rest of Season" on the page. Three of those are the same word in different clothes.

One word now, `season`, everywhere except the label a manager reads, where "Rest of Season" says what it means. A data migration renames the 564 stored rows, so the column and the code agree. `RestOfSeasonForecast` becomes `SeasonForecast`.

### Give the season a page of its own

`/gameweeks/ros` says a season is a kind of gameweek. It is the other way round.

| Before | After |
|---|---|
| `/gameweeks/ros/forwards` | `/season/forwards` |
| `/gameweeks/1/forwards` | unchanged |

The old URL is a **301**, since it may already be indexed. No route for the coming week was needed: the coming week is a numbered week like any other, so "Next Gameweek" keeps pointing at `/gameweeks/:n/:position` exactly as before.

The horizon dropdown submits `gameweek=season` to root and is redirected to the clean URL, the same path the numbered weeks already take. Canonicals follow through one `rankings_path` helper rather than a hardcoded `gameweek_position_path`, which was generating an invalid URL for the season view.

### One thing found along the way

The sitemap builds from `Gameweek.joins(:forecasts).pluck(:fpl_id)`, so it has **never listed the rest-of-season pages**. They are the only ranking URLs that stay right all year. They are in it now.

---

180 tests, 0 failures, RuboCop clean. Covers the new route, both redirects, and a team filter surviving the trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcEXK6XpvnLXMHoUuywLeo