### PR TITLE
Charge an injured player for the injury once, not twice

### DIFF
--- a/app/services/availability.rb
+++ b/app/services/availability.rb
@@ -31,7 +31,13 @@ class Availability < ApplicationService
   # It stops being a guess once we have watched these flags clear. We already
   # store every player's fitness week by week, so by Christmas this can be the
   # measured figure rather than an assumed one.
-  UNKNOWN_LAYOFF = 3.months
+  #
+  # It is also, now, the only thing standing between an injured player and his
+  # own record. It used to share the job with the crowd, whose ownership had
+  # collapsed on the same news, and the two together came to about five months
+  # without anyone choosing five months. One number somebody picked on purpose
+  # beats two nobody did. See ExpectedPoints#ruled_out?.
+  UNKNOWN_LAYOFF = 4.months
 
   # A doubt is about one weekend, not a season. Over a long horizon it costs him
   # that week and nothing more.

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -301,8 +301,35 @@ class ExpectedPoints < ApplicationService
   end
 
   # A costly vote is a considered one, so the dearer the player the more of the
-  # answer his backing decides.
+  # answer his backing decides. Unless he cannot play, in which case it decides
+  # nothing: see #ruled_out?.
   def crowd_share(ranking)
+    return 0.0 if ruled_out?(ranking)
+
+    considered_share(ranking)
+  end
+
+  # Whether FPL has said he cannot play the coming week.
+  #
+  # His ownership has collapsed because of that same news, so letting the crowd
+  # speak charges him for the injury twice: once in his availability, and again
+  # in an ordering that is only low because he is hurt. Saliba is our own third
+  # or fourth best defender on the record, and a rest-of-season page had him
+  # sixty-eighth, most of which was managers selling a man we had already marked
+  # unfit.
+  #
+  # So on a player who cannot play, their money tells us nothing we have not
+  # already counted, and his own record does the talking. What being out costs
+  # him is then one honest number rather than two vague ones multiplied: see
+  # Availability.
+  #
+  # It changes nothing in the weekly forecast, where being ruled out takes him to
+  # nought whatever anybody thinks of him.
+  def ruled_out?(ranking)
+    optional_stat(ranking, "chance_of_playing")&.zero?
+  end
+
+  def considered_share(ranking)
     base = CROWD_SHARE_MIN + (CROWD_SHARE_MAX - CROWD_SHARE_MIN) * dearness(ranking)
     (base * @crowd_weight).clamp(0.0, 1.0)
   end

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -90,6 +90,17 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     assert result[2][:points] > result[1][:points]
   end
 
+  test "a player who cannot play is judged on his record, not on managers selling him" do
+    rankings = [ ranking(1), ranking(2) ]
+    stats = { 1 => regular.merge("chance_of_playing" => 0.0), 2 => regular }
+
+    result = forecast(rankings, stats)
+
+    assert_equal 0.0, result[1][:working][:crowd_share],
+                 "his ownership is a reaction to news we have already counted"
+    assert result[2][:working][:crowd_share].positive?, "everybody else's backing still decides its share"
+  end
+
   test "a blank gameweek is nought points, and a double is worth about twice one game" do
     rankings = [ ranking(1, team_id: 1), ranking(2, team_id: 2), ranking(3, team_id: 3) ]
     stats = { 1 => regular, 2 => regular, 3 => regular }


### PR DESCRIPTION
Item 3 from the outstanding list. The two open questions turned out to be the same question.

## The double count

A player FPL has ruled out is one we have **already** marked unfit through `availability`. His ownership has also collapsed, because of that same news. Letting the crowd speak charges him for the injury twice: once in his availability, and again in an ordering that is only low because he is hurt.

Saliba, rest of season:

```
ours 4.38   crowd 2.20   crowd_share 0.655   availability 0.82
```

We rate him our third or fourth best defender on his record. The page had him **68th**, and most of that gap was managers selling a man we had already docked.

So on a player who cannot play, the crowd is quiet and his record does the talking.

## The layoff was never really three months

With the double count gone, `UNKNOWN_LAYOFF` is the only thing standing between an injured player and his record. Which means we can finally see what we were assuming. Rest-of-season rank, same data throughout:

| | today | 3 months | 4 months | 5 months | 6 months |
|---|---|---|---|---|---|
| Saliba | #68 | #19 | **#46** | #68 | #92 |
| Ekitiké | #34 | #15 | #16 | #21 | #28 |
| Timber | #32 | #3 | #3 | #3 | #3 |

**Five months reproduces today's ordering exactly.** That is what the two mechanisms multiplied out to, and nobody chose it. One number picked on purpose beats two nobody did.

Set to four. It is one line, and the table above says what three or five would give instead. It stops being a guess entirely once we have watched enough flags clear to measure how long they actually last, which our week-by-week fitness records will show by Christmas.

Timber doesn't move with the constant because FPL names his return date (21 Aug), so he's fit for essentially the whole season either way. His jump to #3 is the boldest thing in this PR, and it is really our model asserting he is an elite defender, which the crowd's reaction to his groin strain had been masking.

## Blast radius

**The weekly forecast does not move at all.** Being ruled out already takes a player to nought whatever anyone thinks of him, so this only ever mattered over a longer horizon.

Over the season, seven players move ten places or more, and they move **both ways**:

| | Before | After |
|---|---|---|
| Timber (ARS) | #32 | #3 |
| Ekitiké (LIV) | #34 | #16 |
| Andersen (FUL) | #83 | #32 |
| Saliba (ARS) | #68 | #46 |
| Xavi (TOT) | #78 | #100 |
| Kroupi Jr (BOU) | #45 | #67 |

The drops matter as much as the rises: a record can say less than the crowd did as easily as more, so this is "judge him on his record", not "promote the injured".

178 tests, RuboCop clean. Every figure measured with both sides against identical data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJM9XstRaYZz5N7RYyxaP