### PR TITLE
Apply the fixture where the opponent has a say, and nowhere else

### DIFF
--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -107,10 +107,40 @@ class ExpectedPoints < ApplicationService
   # enough to make one haul outrank a season of evidence.
   FORM_SWING = 0.2
 
-  # A kind fixture is worth about a tenth either way. More than that claims FPL's
-  # one-to-five difficulty knows more than it does.
-  FIXTURE_SWING = 0.05
+  # How much the opponent matters, which depends entirely on what a player is
+  # paid for.
+  #
+  # This used to be one number applied to the whole score, and that was wrong
+  # three ways at once. Two points for turning up are the same against Arsenal as
+  # against a promoted side, and no opponent can touch them. A clean sheet is the
+  # opposite: who you are playing decides almost all of it, and the rate varies
+  # about threefold between the kindest fixture in the game and the cruellest. A
+  # goalkeeper's saves run the other way entirely, because a hard afternoon is a
+  # busy one, and marking his saves down for a tough fixture had us paying him
+  # least exactly when he had most to do.
+  #
+  # So the fixture is applied where the opponent has a say, in proportion to how
+  # much say he has, and nowhere else. Difficulty runs one to five about a middle
+  # of three, so the half-range below turns that into a number from minus one for
+  # the worst fixture to plus one for the best.
+  # Each step of difficulty multiplies rather than adds, because that is how the
+  # real rates behave: a clean sheet is not a fixed number of percentage points
+  # harder against each better side, it is a fraction as likely.
   AVERAGE_DIFFICULTY = 3
+
+  # Clean sheets swing hardest. A step of a third per grade of difficulty tracks
+  # the real spread closely: about two afternoons in five against the weakest
+  # sides, under one in seven against the strongest, and a bit over one in four in
+  # between.
+  CLEAN_SHEET_STEP = 1.3
+
+  # Goals and assists move too, but far less. A good forward scores against good
+  # sides, which is most of what makes him a good forward.
+  ATTACK_STEP = 1.1
+
+  # Saves run the other way, so this one sits below one: the afternoon that denies
+  # a goalkeeper his clean sheet is the afternoon that keeps him busy.
+  SAVE_STEP = 0.87
 
   # What the crowd is willing to pay for him, and how far we let that speak.
   #
@@ -184,7 +214,8 @@ class ExpectedPoints < ApplicationService
   def self.parameters
     {
       regular_share: REGULAR_SHARE, unproven_minutes: UNPROVEN_MINUTES,
-      form_swing: FORM_SWING, fixture_swing: FIXTURE_SWING,
+      form_swing: FORM_SWING, clean_sheet_step: CLEAN_SHEET_STEP,
+      attack_step: ATTACK_STEP, save_step: SAVE_STEP,
       crowd_share_min: CROWD_SHARE_MIN, crowd_share_max: CROWD_SHARE_MAX,
       crowd_weight: CROWD_WEIGHT, price_power: PRICE_POWER,
       new_club_minutes: NEW_CLUB_MINUTES, nailed_on: NAILED_ON, cheapest: CHEAPEST,
@@ -427,17 +458,41 @@ class ExpectedPoints < ApplicationService
   # THE SECOND TERM: what he is worth per 90 minutes, from what he actually does
   # rather than what he happened to score, priced with FPL's own scoring table.
   # Appearance points are left out: everyone in a position gets the same two.
-  def points_per_90(ranking)
-    APPEARANCE + scoring_per_90(ranking)
+  # Against nobody in particular unless a fixture is named, which is how the
+  # crowd's curve and a player's own standing are read: both are about what he is
+  # worth on an ordinary afternoon.
+  def points_per_90(ranking, fixture = nil)
+    APPEARANCE + scoring_per_90(ranking, fixture)
   end
 
   # What he adds beyond turning up. Shrunk for a thin record and moved by his
   # recent run, neither of which should touch the appearance points: those are
   # certain the moment he is on the pitch.
-  def scoring_per_90(ranking)
-    earned = goal_points(ranking) + assist_points(ranking) +
-             clean_sheet_points(ranking) + save_points(ranking) + bonus_points(ranking)
-    earned * credibility(ranking) * form_factor(ranking)
+  def scoring_per_90(ranking, fixture = nil)
+    earned_against(ranking, fixture) * credibility(ranking) * form_factor(ranking)
+  end
+
+  # Each part of what he earns, moved by however much the opponent has to say
+  # about that part. Bonus is left where it is: it is awarded for being among the
+  # best three on the day, which is a comparison with the other twenty-one men on
+  # the pitch rather than with the badge on their shirts.
+  def earned_against(ranking, fixture)
+    attacking_points(ranking) * swing(ATTACK_STEP, fixture) +
+      clean_sheet_points(ranking) * swing(CLEAN_SHEET_STEP, fixture) +
+      save_points(ranking) * swing(SAVE_STEP, fixture) +
+      bonus_points(ranking)
+  end
+
+  def attacking_points(ranking)
+    goal_points(ranking) + assist_points(ranking)
+  end
+
+  # How far one part of a score is moved by who he is playing. No fixture named
+  # means no opinion, which leaves the figure as it stands.
+  def swing(step, fixture)
+    return 1.0 if fixture.nil?
+
+    step**(AVERAGE_DIFFICULTY - difficulty_of(fixture))
   end
 
   # Bonus is awarded per match to the three best performers, so it is not in any
@@ -496,11 +551,24 @@ class ExpectedPoints < ApplicationService
     played / (played + UNPROVEN_MINUTES)
   end
 
-  # THE THIRD TERM: the games in front of him. One ordinary fixture is worth about
-  # 1, a kind one a little more, and a team playing twice gets two goes at it. A
-  # blank week is nought, which is the honest answer.
+  # THE THIRD TERM: the games in front of him, each counted for what it is worth
+  # to this player. A team playing twice gets two goes at it and a blank week is
+  # nought, which is the honest answer.
+  #
+  # An ordinary fixture is worth 1. A kind one is worth more to a defender than
+  # to a forward, and a cruel one costs a goalkeeper less than it costs anybody,
+  # because the same afternoon that denies him a clean sheet brings him saves.
+  # See CLEAN_SHEET_SWING and the constants around it.
   def games_ahead(ranking)
-    fixtures_for(ranking).sum { |fixture| 1 + (AVERAGE_DIFFICULTY - difficulty_of(fixture)) * FIXTURE_SWING }
+    fixtures_for(ranking).sum { |fixture| worth_of(ranking, fixture) }
+  end
+
+  # What this fixture is worth against an ordinary one, for this player.
+  def worth_of(ranking, fixture)
+    ordinary = points_per_90(ranking)
+    return 1.0 unless ordinary.positive?
+
+    points_per_90(ranking, fixture) / ordinary
   end
 
   # An unrated fixture counts as an ordinary one. Treating it as unplayable would

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -101,6 +101,39 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     assert result[2][:working][:crowd_share].positive?, "everybody else's backing still decides its share"
   end
 
+  test "turning up is worth the same whoever the opponent is" do
+    rankings = [ ranking(1) ]
+    stats = { 1 => regular(xg: 0.0, xgi: 0.0, clean_sheets: 0.0) } # paid for nothing but being there
+
+    kind = forecast(rankings, stats, fixtures: { 1 => [ fixture(1) ] })
+    cruel = forecast(rankings, stats, fixtures: { 1 => [ fixture(5) ] })
+
+    assert_equal kind[1][:points], cruel[1][:points],
+                 "no opponent can change what a man gets for being on the pitch"
+  end
+
+  test "a hard afternoon costs a defender his clean sheet and brings a goalkeeper saves" do
+    rankings = [ ranking(1, position: "defender"), ranking(2, position: "goalkeeper") ]
+    stats = { 1 => regular(clean_sheets: 0.35),
+              2 => regular(clean_sheets: 0.35).merge("last_season_saves_per_90" => 3.0) }
+
+    cruel = forecast(rankings, stats, fixtures: { 1 => [ fixture(5) ] })
+
+    assert cruel[1][:working][:games] < 1.0, "the defender is unlikely to keep one"
+    assert cruel[2][:working][:games] > cruel[1][:working][:games],
+           "and his goalkeeper minds less, because the shots come to him"
+  end
+
+  test "a kind fixture is worth most to the defender with the best record of clean sheets" do
+    rankings = [ ranking(1, position: "defender"), ranking(2, position: "defender") ]
+    stats = { 1 => regular(clean_sheets: 0.50), 2 => regular(clean_sheets: 0.10) }
+
+    kind = forecast(rankings, stats, fixtures: { 1 => [ fixture(1) ] })
+
+    assert kind[1][:working][:games] > kind[2][:working][:games],
+           "a fixture can only be worth what the player would do with it"
+  end
+
   test "a blank gameweek is nought points, and a double is worth about twice one game" do
     rankings = [ ranking(1, team_id: 1), ranking(2, team_id: 2), ranking(3, team_id: 3) ]
     stats = { 1 => regular, 2 => regular, 3 => regular }


### PR DESCRIPTION
From the observation that managers are piling into Man Utd defenders for GW1 while we have them at #10 and #13.

## Three errors, not one

Difficulty was a single number multiplied through the whole score:

```ruby
fixtures_for(ranking).sum { |f| 1 + (AVERAGE_DIFFICULTY - difficulty_of(f)) * FIXTURE_SWING }
```

1. **Appearance points moved with the fixture.** Two points for turning up are the same against Arsenal as against a promoted side. A hard away trip was cutting them to 1.8.
2. **Clean sheets barely moved, and they should move most.** `4 × clean_sheets_per_90` is opponent-blind, then got the same ±5% as everything else.
3. **Goalkeeper saves moved the wrong way.** A hard afternoon is a busy one. We were paying a keeper least exactly when he had most to do.

## The fix

Difficulty comes out of the game count, leaving that as an honest count of fixtures (0 for a blank, 1, 2 for a double), and goes into the parts of a score it belongs to: hardest on clean sheets, lightly on goals and assists, inverted on saves, not at all on appearance points or bonus.

Each step multiplies rather than adds, because that is how the real rates behave. A clean sheet is not a fixed number of percentage points harder against each better side, it is a fraction as likely: roughly two afternoons in five against the weakest sides, under one in seven against the strongest.

## What it does

At the extremes, which is where it should show. **Same fixture, Bournemouth at difficulty 5:**

| | Before | After |
|---|---|---|
| Petrović, goalkeeper | 0.90 | **0.961** |
| Truffert, defender | 0.90 | **0.879** |

A keeper and his own centre-back used to be docked identically. And in the other direction, a kind fixture is now worth **+8.2% to Gabriel** against **+6.5% to Shaw**, where both got a flat +5%, because Gabriel keeps twice as many clean sheets and so has twice as much to gain.

## What it does not do

**Nothing moves more than one place in any top ten.** That is the honest answer to whether the fixture should count for more: it cannot.

Shaw's expected points:

```
appearance     2.00   60%   untouchable by any opponent
clean sheet    0.98   30%   the opponent decides nearly all of it
everything else 0.34  10%
```

Even a maximally kind fixture only reaches the 30%. Lifting Shaw from 3.9 to 5.0 would need Man Utd's clean sheet rate at Hull to be about 60%, against the 25% they managed last season. That is not a weighting question, it is a claim about their defence.

What managers are buying is a bet that the defence has improved plus the variance of a clean sheet. That is the crowd's job, and it is already working: Shaw is 24% owned, the crowd rates him 4.38 against our 3.32, and that is what carries him to #10 in the first place.

## Notes

- 184 tests, RuboCop clean
- New tests cover all three fixed errors: appearance points identical across difficulty 1 and 5, a keeper docked less than his own defender on the same hard fixture, and a kind fixture worth more to the defender with the better clean sheet record
- FPL's richer `strength_attack_*` and `strength_defence_*` ratings are all zero pre-season, so this still rides on the coarse 1-to-5 difficulty. Worth revisiting once they populate
- Every figure measured with both sides against identical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJM9XstRaYZz5N7RYyxaP