### PR TITLE
Let a strategy be the receipt it is, not a switch

### DIFF
--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -12,15 +12,8 @@ class Strategy < ApplicationRecord
   end
 
   validate :strategy_config_present
-  validate :position_valid, if: -> { position.present? }
-
 
   def strategy_config_present
     errors.add(:strategy_config, "can't be nil") if strategy_config.nil?
-  end
-
-  def position_valid
-    valid_positions = FantasyForecast::POSITION_CONFIG.keys
-    errors.add(:position, "must be one of: #{valid_positions.join(', ')}") unless valid_positions.include?(position)
   end
 end

--- a/app/services/forecaster.rb
+++ b/app/services/forecaster.rb
@@ -153,9 +153,19 @@ class Forecaster < ApplicationService
       created_at: now, updated_at: now }
   end
 
+  # A player's record as it stood by this gameweek, latest reading first claim.
+  #
+  # Live this changes nothing, because a forecast for the coming week is made
+  # before any later week has a reading to give. It matters when the week is
+  # re-run: marking one set of settings against another means making the same
+  # forecast twice from the same evidence, and evidence gathered after the
+  # football is not evidence, it is hindsight. Left unscoped, a settings change
+  # tried in November would be handed November's form to forecast August with,
+  # and would beat the settings that had to guess. Every time.
   def stats_for(players)
     stats = Hash.new { |hash, key| hash[key] = {} }
     Statistic.where(player_id: players.map(&:id), type: ExpectedPoints::STAT_TYPES)
+             .where(gameweek_id: ..@gameweek.id)
              .order(:gameweek_id)
              .pluck(:player_id, :type, :value)
              .each { |player_id, type, value| stats[player_id][type] = value.to_f }

--- a/db/migrate/20260802230000_remove_bot_columns_from_strategies.rb
+++ b/db/migrate/20260802230000_remove_bot_columns_from_strategies.rb
@@ -1,0 +1,13 @@
+# A strategy used to be a bot you switched on for a position and tuned over time.
+# It is now a record of the parameters a forecast was made with, and a record is
+# not something you switch off, assign to a position, or optimise. Nothing has
+# read these columns since; they only invited the question of why twelve sets of
+# settings were all active at once.
+class RemoveBotColumnsFromStrategies < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :strategies, :active, :boolean, default: true, null: false
+    remove_column :strategies, :position, :string
+    remove_column :strategies, :last_optimized_at, :datetime
+    remove_column :strategies, :optimization_log, :jsonb, default: [], null: false
+  end
+end

--- a/db/migrate/20260802230100_delete_strategies_without_forecasts.rb
+++ b/db/migrate/20260802230100_delete_strategies_without_forecasts.rb
@@ -1,0 +1,18 @@
+# Settings nothing was ever forecast with: the old positional bots, and every set
+# left behind when a re-run of the same gameweek repointed its forecasts at the
+# settings that replaced them. They say nothing about any forecast we hold, so
+# they are noise in the only question this table exists to answer.
+class DeleteStrategiesWithoutForecasts < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL
+      DELETE FROM strategies
+      WHERE NOT EXISTS (
+        SELECT 1 FROM forecasts WHERE forecasts.strategy_id = strategies.id
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260802230200_delete_rest_of_season_forecasts.rb
+++ b/db/migrate/20260802230200_delete_rest_of_season_forecasts.rb
@@ -1,0 +1,24 @@
+# The season horizon was renamed and its rows renamed with it, but checkouts that
+# predate the rename went on writing the old name, so a second set of the same 564
+# forecasts came back under a horizon nothing reads. Every one has a season row for
+# the same player and gameweek, so there is nothing here to keep.
+#
+# The settings behind them go too, on the same terms as the migration before this
+# one: a set of parameters no forecast points at says nothing about any forecast we
+# hold.
+class DeleteRestOfSeasonForecasts < ActiveRecord::Migration[8.1]
+  def up
+    execute "DELETE FROM forecasts WHERE horizon = 'rest_of_season'"
+
+    execute <<~SQL
+      DELETE FROM strategies
+      WHERE NOT EXISTS (
+        SELECT 1 FROM forecasts WHERE forecasts.strategy_id = strategies.id
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_220000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_230200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -129,14 +129,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_220000) do
   end
 
   create_table "strategies", force: :cascade do |t|
-    t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
-    t.datetime "last_optimized_at"
-    t.jsonb "optimization_log", default: [], null: false
-    t.string "position"
     t.jsonb "strategy_config", default: {}, null: false
     t.datetime "updated_at", null: false
-    t.index ["active"], name: "index_strategies_on_active"
   end
 
   create_table "teams", force: :cascade do |t|

--- a/test/fixtures/strategies.yml
+++ b/test/fixtures/strategies.yml
@@ -2,8 +2,6 @@
 
 one:
   strategy_config: {}
-  active: true
 
 two:
   strategy_config: {}
-  active: true

--- a/test/models/strategy_test.rb
+++ b/test/models/strategy_test.rb
@@ -6,46 +6,25 @@ class StrategyTest < ActiveSupport::TestCase
   end
 
   test "valid strategy with config" do
-    strategy = Strategy.new(
-      strategy_config: @valid_config,
-      active: true
-    )
+    strategy = Strategy.new(strategy_config: @valid_config)
 
     assert strategy.valid?
   end
 
   test "requires strategy_config to be present" do
-    strategy = Strategy.new(
-      strategy_config: nil,
-      active: true
-    )
+    strategy = Strategy.new(strategy_config: nil)
 
     assert_not strategy.valid?
     assert_includes strategy.errors[:strategy_config], "can't be nil"
   end
 
+  # Two forecasts made with the same settings are looked up, not rejected, so
+  # nothing here may stop the same set of parameters being written twice.
   test "allows duplicate strategy_config" do
-    Strategy.create!(
-      strategy_config: @valid_config,
-      active: true
-    )
+    Strategy.create!(strategy_config: @valid_config)
 
-    duplicate_strategy = Strategy.create!(
-      strategy_config: @valid_config,
-      active: true
-    )
+    duplicate_strategy = Strategy.create!(strategy_config: @valid_config)
 
     assert duplicate_strategy.persisted?
-  end
-
-  test "allows updating strategy" do
-    strategy = Strategy.create!(
-      strategy_config: @valid_config,
-      active: true
-    )
-
-    strategy.active = false
-    assert strategy.valid?
-    assert strategy.save
   end
 end

--- a/test/services/weekly_forecast_test.rb
+++ b/test/services/weekly_forecast_test.rb
@@ -62,6 +62,18 @@ class WeeklyForecastTest < ActiveSupport::TestCase
                  "what produced last week's forecast must not change under it"
   end
 
+  test "reads only the record that stood by this gameweek" do
+    WeeklyForecast.call(gameweek: @gameweek)
+    was = Forecast.find_by(player: @player, gameweek: @gameweek).score
+
+    later = Gameweek.create!(fpl_id: 81, name: "Gameweek 81", start_time: 9.days.from_now)
+    Statistic.create!(player: @player, gameweek: later, type: "expected_goals_per_90", value: 5.0)
+    WeeklyForecast.call(gameweek: @gameweek)
+
+    assert_equal was, Forecast.find_by(player: @player, gameweek: @gameweek).score,
+                 "a week cannot be re-forecast with form it could not have known"
+  end
+
   test "refuses to write a position it cannot score anybody in" do
     Match.destroy_all # nobody has a fixture, so everybody multiplies to nought
 


### PR DESCRIPTION
A strategy used to be a bot you turned on for a position and tuned over time. It is now a record of the parameters a forecast was made with, and nothing had read the switches since. Twelve sets of settings were sitting there "active" at once, which is the question that started this.

**Dead columns go.** `active`, `position`, `last_optimized_at` and `optimization_log`, along with `position_valid` and the test that only asserted a boolean could be flipped. `strategies` is now its config and its timestamps.

**Settings no forecast points at go too.** The old positional bots, and every set orphaned when a re-run of the same gameweek repointed its forecasts at whatever replaced it. Locally that was 23 rows down to 3.

**So do the rows left under the season's old name.** Checkouts predating the rename kept writing `rest_of_season` after the rename migration had cleaned it up. Every one has a `season` row for the same player and gameweek, checked before deleting.

**And a forecast now reads only the record that stood by its gameweek.** This is the one behavioural change. Live it is a no-op, because the coming week is forecast before any later week has a reading to give, and nothing writes statistics ahead of the gameweek being forecast. It matters on a re-run: without it, settings tried in November would be handed November's form to forecast August with and would win every time. Which makes the whole point of keeping these receipts moot.

Two migrations delete rows and are irreversible by design. On production they will most likely find nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9YYWVSRf761RLB2RtQbzR