### PR TITLE
Send the season dropdown to the season's own page

### DIFF
--- a/app/javascript/controllers/filter_navigation_controller.js
+++ b/app/javascript/controllers/filter_navigation_controller.js
@@ -11,7 +11,13 @@ export default class extends Controller {
     const teamId = data.get("team_id")
 
     const plurals = { goalkeeper: "goalkeepers", defender: "defenders", midfielder: "midfielders", forward: "forwards" }
-    let path = `/gameweeks/${gameweek}/${plurals[position] || `${position}s`}`
+    const plural = plurals[position] || `${position}s`
+
+    // The season has a page of its own; a week is named by its number. This
+    // mirrors PlayersController#rankings_path, and has to: sending the season to
+    // /gameweeks/season is a route that has never existed, and Turbo answers a
+    // 404 inside a frame with the words "Content missing".
+    let path = gameweek === "season" ? `/season/${plural}` : `/gameweeks/${gameweek}/${plural}`
 
     const params = new URLSearchParams()
     if (teamId) params.set("team_id", teamId)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,7 +8,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     WebMock.allow_net_connect!
   end
 
+  # Localhost stays open afterwards. Capybara shuts the browser down at exit,
+  # long after the last teardown has run, and closing the door on the driver's
+  # own port fails the whole suite on the way out.
   teardown do
-    WebMock.disable_net_connect!
+    WebMock.disable_net_connect!(allow_localhost: true)
   end
 end

--- a/test/system/rankings_test.rb
+++ b/test/system/rankings_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+# The horizon dropdown is driven by JavaScript, which builds the URL it visits.
+# That makes it the one part of the rankings page no controller test can reach:
+# when the season was renamed, the dropdown kept sending managers to a route that
+# no longer existed, every request returned a 404, and Turbo wrote "Content
+# missing" into the frame. Everything else was green.
+class RankingsTest < ApplicationSystemTestCase
+  setup do
+    Forecast.destroy_all
+    Gameweek.destroy_all
+    @team = Team.create!(fpl_id: 970, name: "Test City", short_name: "TCY", code: 970)
+    @gameweek = Gameweek.create!(fpl_id: 1, name: "Gameweek 1", start_time: 2.days.from_now, is_next: true)
+    @player = Player.create!(first_name: "Test", last_name: "Defender", short_name: "T.Defender",
+                             fpl_id: 9700, code: 9700, team: @team, position: "defender")
+    Forecast.create!(player: @player, gameweek: @gameweek, rank: 1, score: 5.0, horizon: "gameweek")
+    Forecast.create!(player: @player, gameweek: @gameweek, rank: 1, score: 180.0, horizon: "season")
+  end
+
+  test "switching the horizon to the season shows the season's rankings" do
+    visit gameweek_position_path(gameweek: 1, position: "defenders")
+    assert_text @player.short_name
+
+    select "Rest of Season", from: "gameweek"
+
+    # The frame should hold rankings, not Turbo's missing-content notice.
+    assert_no_text "Content missing"
+    assert_text @player.short_name
+    assert_current_path season_position_path(position: "defenders")
+  end
+
+  test "switching back to the coming week shows that week's rankings" do
+    visit season_position_path(position: "defenders")
+
+    select "Next Gameweek", from: "gameweek"
+
+    assert_text @player.short_name
+    assert_no_text "Content missing"
+    assert_current_path gameweek_position_path(gameweek: 1, position: "defenders")
+  end
+end


### PR DESCRIPTION
Fixes the live bug: switching the horizon to Rest of Season shows **"Content missing"**.

## What broke

That phrase is Turbo's, not ours. It is what a `<turbo-frame>` shows when the response has no matching frame, which here means the request 404'd.

Renaming the horizon (#92) moved the season page from `/gameweeks/ros/:position` to `/season/:position` and tightened the gameweek route to `/\d+/`. One place still builds that URL by hand:

```js
let path = `/gameweeks/${gameweek}/${plural}`
```

The dropdown's season option carries the value `season`, so it asked for `/gameweeks/season/defenders`. Confirmed against production:

```
200  /
200  /season/defenders
200  /gameweeks/ros/defenders     (the 301 still works)
200  /gameweeks/1/defenders
404  /gameweeks/season/defenders  <- what the dropdown asks for
```

## Why nothing caught it

Everything else about that rename was done properly. The route was right, the controller was right, a data migration renamed the stored horizon values, and the redirect for the old URL was in place. The page serves correct content to anyone who requests it directly, which is why every controller test stayed green.

The only broken part was a string built in a Stimulus controller, which is the one part of that page no controller test can reach.

## The fix

```js
let path = gameweek === "season" ? `/season/${plural}` : `/gameweeks/${gameweek}/${plural}`
```

Mirrors `PlayersController#rankings_path`, with a comment on each side saying so.

## The first system test

Pick Rest of Season from the dropdown, expect rankings rather than Turbo's notice, then pick the week back again. I verified it **fails with the old path and passes with the new one**, rather than trusting a green run.

CI already runs `test test:system`, so this guards the regression properly.

Running them surfaced a second thing. The harness disabled WebMock in `teardown`, and Capybara closes the browser at exit, long after the last teardown has run, so the driver's own shutdown request was blocked and errored the whole suite. Localhost stays open now. Nobody had hit it because there were no system tests to run.

## Worth knowing

The Stimulus controller still duplicates routing knowledge the server already owns, so a future route change can break it the same way. The durable fix is to have Rails render the destination into the form rather than have JavaScript reconstruct it. I have not done that here, since a production bug wants the smallest correct change, but it is worth doing on purpose rather than after the next outage.

186 tests (184 + 2 system), RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJM9XstRaYZz5N7RYyxaP