### PR TITLE
Add a price bracket filter to the rankings

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,60 @@
 @import "tailwindcss";
+
+.price-slider input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  background: transparent;
+}
+
+.price-slider input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  pointer-events: auto;
+  height: 1rem;
+  width: 1rem;
+  border-radius: 9999px;
+  background: #18181b;
+  border: 2px solid #ffffff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+}
+
+.price-slider input[type="range"]::-moz-range-thumb {
+  pointer-events: auto;
+  height: 1rem;
+  width: 1rem;
+  border-radius: 9999px;
+  background: #18181b;
+  border: 2px solid #ffffff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+}
+
+.price-slider input[type="range"]::-moz-range-track {
+  background: transparent;
+}
+
+.price-slider__track,
+.price-slider__range {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  border-radius: 9999px;
+  transform: translateY(-50%);
+}
+
+.price-slider__track {
+  left: 0;
+  right: 0;
+  background: #e4e4e7;
+}
+
+.price-slider__range {
+  background: #18181b;
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -11,28 +11,29 @@
   height: 100%;
   margin: 0;
   background: transparent;
+  touch-action: none;
 }
 
 .price-slider input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
   pointer-events: auto;
-  height: 1rem;
-  width: 1rem;
+  height: 1.25rem;
+  width: 1.25rem;
   border-radius: 9999px;
   background: #18181b;
   border: 2px solid #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   cursor: pointer;
 }
 
 .price-slider input[type="range"]::-moz-range-thumb {
   pointer-events: auto;
-  height: 1rem;
-  width: 1rem;
+  height: 1.25rem;
+  width: 1.25rem;
   border-radius: 9999px;
   background: #18181b;
   border: 2px solid #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   cursor: pointer;
 }
 

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -179,7 +179,7 @@ class PlayersController < ApplicationController
   end
 
   def load_consensus_rankings
-    rankings = ConsensusRanking.call(@gameweek, @position_filter, @team_filter, horizon: @horizon)
+    rankings = ConsensusRanking.call(@gameweek, @position_filter, nil, horizon: @horizon)
     @consensus_rankings = TierCalculator.call(rankings, position: @position_filter, points_divisor: tier_divisor)
     @tier_groups = @consensus_rankings.group_by(&:tier)
   end
@@ -262,11 +262,19 @@ class PlayersController < ApplicationController
   #
   # Ranks are renumbered afterwards so the page reads 1, 2, 3.
   def build_shortlist
-    @consensus_rankings = @consensus_rankings.select { |ranking| ranking.score.to_f.positive? }
-                                             .select { |ranking| priced_within_band?(ranking.player_id) }
-                                             .first(RANKING_DEPTH.fetch(@position_filter, 100))
-    @consensus_rankings.each_with_index { |ranking, index| ranking.bot_rank = index + 1 }
+    field = @consensus_rankings.select { |ranking| ranking.score.to_f.positive? }
+                               .first(RANKING_DEPTH.fetch(@position_filter, 100))
+    field.each_with_index { |ranking, index| ranking.bot_rank = index + 1 }
+    @consensus_rankings = field.select { |ranking| within_filters?(ranking) }
     @tier_groups = @consensus_rankings.group_by(&:tier)
+  end
+
+  def within_filters?(ranking)
+    matches_team?(ranking) && priced_within_band?(ranking.player_id)
+  end
+
+  def matches_team?(ranking)
+    @team_filter.nil? || ranking.team_id == @team_filter
   end
 
   def priced_within_band?(player_id)

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -9,6 +9,10 @@ class PlayersController < ApplicationController
     "goalkeeper" => 50, "defender" => 100, "midfielder" => 100, "forward" => 50
   }.freeze
 
+  TENTHS_PER_MILLION = 10
+
+  PRICE_STEP = 5
+
   # The horizon that spans every gameweek that remains, as the routes and the
   # stored forecasts both spell it.
   SEASON = "season".freeze
@@ -112,7 +116,7 @@ class PlayersController < ApplicationController
 
   def build_clean_url
     rankings_path(params[:gameweek], resolve_position(params[:position]),
-                  **params.permit(:team_id).to_h.compact_blank.symbolize_keys)
+                  **params.permit(:team_id, :min_price, :max_price).to_h.compact_blank.symbolize_keys)
   end
 
   # Where a horizon lives. The season has a page of its own; a week is named by
@@ -129,6 +133,14 @@ class PlayersController < ApplicationController
     set_horizon
     @position_filter = resolve_position(params[:position])
     @team_filter = params[:team_id].present? ? params[:team_id].to_i : nil
+    @min_price = price_param(params[:min_price])
+    @max_price = price_param(params[:max_price])
+  end
+
+  def price_param(value)
+    return if value.blank?
+
+    (value.to_f * TENTHS_PER_MILLION).round
   end
 
   # The season horizon is anchored to the next gameweek: its rows are stored
@@ -160,7 +172,8 @@ class PlayersController < ApplicationController
   def validate_gameweek
     return true if Gameweek.exists?(fpl_id: @gameweek)
 
-    redirect_to root_path(gameweek: next_gameweek&.fpl_id || 1, position: @position_filter, team_id: @team_filter),
+    redirect_to root_path(gameweek: next_gameweek&.fpl_id || 1, position: @position_filter, team_id: @team_filter,
+                          min_price: params[:min_price], max_price: params[:max_price]),
                 alert: "Gameweek #{@gameweek} not found"
     false
   end
@@ -203,6 +216,36 @@ class PlayersController < ApplicationController
   # table if he deserves to, with both facts there for you to judge.
   def load_row_facts
     @row_facts = latest_snapshot_stats(@consensus_rankings.map(&:player_id), ROW_FACT_TYPES)
+    set_price_bounds
+  end
+
+  def set_price_bounds
+    costs = @row_facts.values.filter_map { |facts| facts["now_cost"] }
+    return if costs.empty?
+
+    floor = (costs.min / PRICE_STEP).floor * PRICE_STEP
+    ceil = (costs.max / PRICE_STEP).ceil * PRICE_STEP
+    clamp_price_band(floor, ceil)
+    @price_filter = price_filter_view(floor, ceil)
+  end
+
+  def clamp_price_band(floor, ceil)
+    @min_price = @min_price&.clamp(floor, ceil)
+    @max_price = @max_price&.clamp(floor, ceil)
+  end
+
+  def price_filter_view(floor, ceil)
+    {
+      floor: to_millions(floor),
+      ceil: to_millions(ceil),
+      min: to_millions(@min_price || floor),
+      max: to_millions(@max_price || ceil),
+      step: to_millions(PRICE_STEP)
+    }
+  end
+
+  def to_millions(tenths)
+    tenths / TENTHS_PER_MILLION.to_f
   end
 
   # Who is worth putting in front of somebody this week.
@@ -220,9 +263,21 @@ class PlayersController < ApplicationController
   # Ranks are renumbered afterwards so the page reads 1, 2, 3.
   def build_shortlist
     @consensus_rankings = @consensus_rankings.select { |ranking| ranking.score.to_f.positive? }
+                                             .select { |ranking| priced_within_band?(ranking.player_id) }
                                              .first(RANKING_DEPTH.fetch(@position_filter, 100))
     @consensus_rankings.each_with_index { |ranking, index| ranking.bot_rank = index + 1 }
     @tier_groups = @consensus_rankings.group_by(&:tier)
+  end
+
+  def priced_within_band?(player_id)
+    return true if @min_price.nil? && @max_price.nil?
+
+    cost = @row_facts.dig(player_id, "now_cost")
+    return false if cost.nil?
+    return false if @min_price && cost < @min_price
+    return false if @max_price && cost > @max_price
+
+    true
   end
 
   def latest_snapshot_stats(player_ids, types)

--- a/app/javascript/controllers/filter_navigation_controller.js
+++ b/app/javascript/controllers/filter_navigation_controller.js
@@ -21,8 +21,22 @@ export default class extends Controller {
 
     const params = new URLSearchParams()
     if (teamId) params.set("team_id", teamId)
+    if (!this.resetPrice) this.appendPrice(params, form)
+    this.resetPrice = false
     if (params.toString()) path += `?${params}`
 
     Turbo.visit(path, { frame: "rankings_container", action: "advance" })
+  }
+
+  positionChanged() {
+    this.resetPrice = true
+    this.element.requestSubmit()
+  }
+
+  appendPrice(params, form) {
+    const min = form.querySelector("input[name='min_price']")
+    const max = form.querySelector("input[name='max_price']")
+    if (min && parseFloat(min.value) > parseFloat(min.min)) params.set("min_price", min.value)
+    if (max && parseFloat(max.value) < parseFloat(max.max)) params.set("max_price", max.value)
   }
 }

--- a/app/javascript/controllers/price_slider_controller.js
+++ b/app/javascript/controllers/price_slider_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["min", "max", "range", "label"]
+
+  connect() {
+    this.paint()
+  }
+
+  onInput(event) {
+    this.enforceOrder(event.target)
+    this.paint()
+  }
+
+  commit() {
+    this.element.closest("form").requestSubmit()
+  }
+
+  enforceOrder(changed) {
+    const min = parseFloat(this.minTarget.value)
+    const max = parseFloat(this.maxTarget.value)
+    if (min <= max) return
+
+    if (changed === this.minTarget) {
+      this.minTarget.value = max
+    } else {
+      this.maxTarget.value = min
+    }
+  }
+
+  paint() {
+    const floor = parseFloat(this.minTarget.min)
+    const ceil = parseFloat(this.minTarget.max)
+    const min = parseFloat(this.minTarget.value)
+    const max = parseFloat(this.maxTarget.value)
+    const span = ceil - floor || 1
+
+    this.rangeTarget.style.left = `${((min - floor) / span) * 100}%`
+    this.rangeTarget.style.right = `${((ceil - max) / span) * 100}%`
+    this.labelTarget.textContent = `£${min.toFixed(1)}m – £${max.toFixed(1)}m`
+  }
+}

--- a/app/views/players/_price_filter.html.erb
+++ b/app/views/players/_price_filter.html.erb
@@ -1,0 +1,20 @@
+<% if @price_filter %>
+  <div class="flex items-center gap-3" data-controller="price-slider">
+    <span class="text-sm text-zinc-500">Price</span>
+    <div class="price-slider relative h-6 w-40">
+      <div class="price-slider__track"></div>
+      <div class="price-slider__range" data-price-slider-target="range"></div>
+      <%= range_field_tag :min_price, @price_filter[:min],
+            min: @price_filter[:floor], max: @price_filter[:ceil], step: @price_filter[:step],
+            "aria-label": "Minimum price",
+            data: { "price-slider-target": "min", action: "input->price-slider#onInput change->price-slider#commit" } %>
+      <%= range_field_tag :max_price, @price_filter[:max],
+            min: @price_filter[:floor], max: @price_filter[:ceil], step: @price_filter[:step],
+            "aria-label": "Maximum price",
+            data: { "price-slider-target": "max", action: "input->price-slider#onInput change->price-slider#commit" } %>
+    </div>
+    <span class="text-sm font-medium text-zinc-900 tabular-nums whitespace-nowrap" data-price-slider-target="label">
+      <%= player_price(@price_filter[:min] * PlayersController::TENTHS_PER_MILLION) %> – <%= player_price(@price_filter[:max] * PlayersController::TENTHS_PER_MILLION) %>
+    </span>
+  </div>
+<% end %>

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -39,16 +39,19 @@
         </div>
 
         <!-- Position Filter -->
-        <div class="flex items-center gap-1" role="radiogroup">
-          <% @available_positions.each do |position| %>
-            <% position_config = FantasyForecast::POSITION_CONFIG[position] %>
-            <% is_active = @position_filter == position %>
-            <label class="px-3 py-1.5 text-sm font-medium rounded-lg cursor-pointer transition-colors <%= is_active ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:text-zinc-900' %>">
-              <%= radio_button_tag :position, position, is_active,
-                  class: "sr-only",
-                  data: { action: "change->filter-navigation#positionChanged" } %><%= position_config[:display_name] %>
-            </label>
-          <% end %>
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-zinc-500">Position</span>
+          <div class="flex items-center gap-1" role="radiogroup">
+            <% @available_positions.each do |position| %>
+              <% position_config = FantasyForecast::POSITION_CONFIG[position] %>
+              <% is_active = @position_filter == position %>
+              <label class="px-3 py-1.5 text-sm font-medium rounded-lg cursor-pointer transition-colors <%= is_active ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:text-zinc-900' %>">
+                <%= radio_button_tag :position, position, is_active,
+                    class: "sr-only",
+                    data: { action: "change->filter-navigation#positionChanged" } %><%= position_config[:display_name] %>
+              </label>
+            <% end %>
+          </div>
         </div>
 
         <%= render "players/price_filter" %>

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -46,10 +46,12 @@
             <label class="px-3 py-1.5 text-sm font-medium rounded-lg cursor-pointer transition-colors <%= is_active ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:text-zinc-900' %>">
               <%= radio_button_tag :position, position, is_active,
                   class: "sr-only",
-                  onchange: "this.form.requestSubmit()" %><%= position_config[:display_name] %>
+                  data: { action: "change->filter-navigation#positionChanged" } %><%= position_config[:display_name] %>
             </label>
           <% end %>
         </div>
+
+        <%= render "players/price_filter" %>
       <% end %>
 
     </div>

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -232,4 +232,45 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to gameweek_position_path(gameweek: 5, position: "forwards",
                                                 min_price: "6.0", max_price: "10.0")
   end
+
+  test "rank reflects the whole field, not the price-filtered subset" do
+    cheap = Player.create!(first_name: "Cheap", last_name: "One", short_name: "C.One",
+                           team: @test_team, position: "forward", fpl_id: 511)
+    mid = Player.create!(first_name: "Mid", last_name: "Two", short_name: "M.Two",
+                         team: @test_team, position: "forward", fpl_id: 512)
+    dear = Player.create!(first_name: "Dear", last_name: "Three", short_name: "D.Three",
+                          team: @test_team, position: "forward", fpl_id: 513)
+
+    Forecast.create!(player: cheap, gameweek: @gameweek5, rank: 1, score: 6.0)
+    Forecast.create!(player: mid, gameweek: @gameweek5, rank: 2, score: 5.0)
+    Forecast.create!(player: dear, gameweek: @gameweek5, rank: 3, score: 4.0)
+    Statistic.create!(player: cheap, gameweek: @gameweek5, type: "now_cost", value: 45)
+    Statistic.create!(player: mid, gameweek: @gameweek5, type: "now_cost", value: 70)
+    Statistic.create!(player: dear, gameweek: @gameweek5, type: "now_cost", value: 95)
+
+    get gameweek_position_path(gameweek: 5, position: "forwards", min_price: "9.0", max_price: "10.0")
+
+    assert_response :success
+    assert_includes response.body, dear.short_name
+    assert_not_includes response.body, cheap.short_name
+    assert_equal "3", response.body[/tabular-nums text-zinc-900">(\d+)</, 1]
+  end
+
+  test "rank reflects the whole field when filtering by team" do
+    other_team = Team.create!(name: "Other", short_name: "OTH", fpl_id: 97)
+    top = Player.create!(first_name: "Top", last_name: "Scorer", short_name: "T.Scorer",
+                         team: other_team, position: "forward", fpl_id: 521)
+    second = Player.create!(first_name: "Second", last_name: "Best", short_name: "S.Best",
+                            team: @test_team, position: "forward", fpl_id: 522)
+
+    Forecast.create!(player: top, gameweek: @gameweek5, rank: 1, score: 6.0)
+    Forecast.create!(player: second, gameweek: @gameweek5, rank: 2, score: 5.0)
+
+    get gameweek_position_path(gameweek: 5, position: "forwards", team_id: @test_team.id)
+
+    assert_response :success
+    assert_includes response.body, second.short_name
+    assert_not_includes response.body, top.short_name
+    assert_equal "2", response.body[/tabular-nums text-zinc-900">(\d+)</, 1]
+  end
 end

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -207,4 +207,29 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     get "/players/non-existent-99999"
     assert_response :not_found
   end
+
+  test "a price band keeps only players who cost within it" do
+    budget = Player.create!(first_name: "Budget", last_name: "Cheapman", short_name: "B.Cheapman",
+                            team: @test_team, position: "forward", fpl_id: 501)
+    premium = Player.create!(first_name: "Premium", last_name: "Dearman", short_name: "P.Dearman",
+                             team: @test_team, position: "forward", fpl_id: 502)
+
+    Forecast.create!(player: budget, gameweek: @gameweek5, rank: 1, score: 5.0)
+    Forecast.create!(player: premium, gameweek: @gameweek5, rank: 2, score: 4.0)
+    Statistic.create!(player: budget, gameweek: @gameweek5, type: "now_cost", value: 50)
+    Statistic.create!(player: premium, gameweek: @gameweek5, type: "now_cost", value: 90)
+
+    get gameweek_position_path(gameweek: 5, position: "forwards", min_price: "6.0", max_price: "10.0")
+
+    assert_response :success
+    assert_includes response.body, premium.short_name
+    assert_not_includes response.body, budget.short_name
+  end
+
+  test "a price band survives the trip to the clean URL" do
+    get root_path(gameweek: 5, position: "forward", min_price: "6.0", max_price: "10.0")
+
+    assert_redirected_to gameweek_position_path(gameweek: 5, position: "forwards",
+                                                min_price: "6.0", max_price: "10.0")
+  end
 end


### PR DESCRIPTION
## What

Adds a price filter so managers can narrow each position's rankings to a price bracket, using a dual-handle slider (one price scale, two points).

## How it works

- **Slider** — a single track with two handles (two overlaid native `range` inputs; no JS libraries). Its range auto-fits the cheapest and dearest player *at the current position*, rounded to £0.5m. Prices live in `statistics` (`now_cost`, in tenths of a million), so the filter runs in-memory against the already-loaded row facts rather than adding a query.
- **Rank is stable** — rank reflects a player's standing in the *whole* position field. The field is ranked first, then team and price act as view filters that hide rows without renumbering. Team filtering moved out of the ranking query into the shortlist for the same reason (so it no longer collapses ranks to 1..N of the subset).
- **Params** — `min_price`/`max_price` ride along as query params (like `team_id`), appended only when they narrow the full range, and reset when the position changes. They survive the clean-URL and invalid-gameweek redirects.

## UI

- The position filter gains a **Position** label to match Show / Team / Price.
- Slider tuned for touch: 20px handles and `touch-action: none` so dragging a handle doesn't scroll the page. Filter groups wrap cleanly on mobile.

## Tests

- Price band filters the shortlist; params survive the clean-URL redirect.
- Rank reflects the whole field when filtering by price, and when filtering by team.
- Full suite: 191 runs, 0 failures. Rubocop clean.

## Note

The depth cap (top 50/100 per position) is applied to the full field *before* filtering, so a narrow cheap band could surface few players if the cheapest all rank beyond the cap — consistent with "rank within all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)