### PR TITLE
Give the hero a shape of its own, not the row's scaled up

### DIFF
--- a/app/components/player_card_component.html.erb
+++ b/app/components/player_card_component.html.erb
@@ -1,56 +1,40 @@
-<div class="flex items-stretch <%= card_height %> rounded-xl overflow-hidden bg-white border border-zinc-200 shadow-sm cursor-pointer"
+<div class="flex items-stretch h-24 rounded-xl overflow-hidden bg-white border border-zinc-200 shadow-sm cursor-pointer"
      onclick="Turbo.visit('<%= helpers.player_path(player) %>')"
      role="link" tabindex="0"
      onkeydown="if(event.key === 'Enter') Turbo.visit('<%= helpers.player_path(player) %>')">
-  <div class="<%= side_width %> shrink-0 flex items-center justify-center <%= corner_text %> font-extrabold tracking-[-0.03em] leading-none tabular-nums text-zinc-900"><%= rank %></div>
+  <div class="w-[54px] shrink-0 flex items-center justify-center text-[32px] font-extrabold tracking-[-0.03em] leading-none tabular-nums text-zinc-900"><%= rank %></div>
 
   <div class="relative flex-1 overflow-hidden">
     <div class="absolute inset-0 z-0 overflow-hidden [clip-path:polygon(18px_0,100%_0,calc(100%_-_32px)_100%,0_100%)]">
       <div class="absolute inset-0" style="background-color: <%= color %>"></div>
       <% if team&.badge_url %>
-        <span class="absolute right-[3px] top-1/2 -translate-y-1/2 <%= badge_size %> pointer-events-none opacity-[.2]">
+        <span class="absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.2]">
           <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain #{team.on_light? ? 'brightness-0' : 'brightness-0 invert'}" %>
         </span>
-        <span class="absolute right-[3px] top-1/2 -translate-y-1/2 <%= badge_size %> pointer-events-none opacity-[.22]">
+        <span class="absolute right-[3px] top-1/2 -translate-y-1/2 h-[120px] w-[120px] pointer-events-none opacity-[.22]">
           <%= image_tag team.badge_url, alt: "", class: "w-full h-full object-contain" %>
         </span>
       <% end %>
     </div>
 
-    <div class="relative z-[1] h-full flex flex-col justify-center <%= banner_pad %> <%= text_class %>">
+    <div class="relative z-[1] h-full flex flex-col justify-center pl-6 <%= text_class %>">
       <% if player.given_name.present? %>
-        <div class="<%= given_text %> font-bold tracking-[-0.02em] uppercase opacity-80 leading-none mb-[3px] whitespace-nowrap"><%= player.given_name %></div>
+        <div class="text-[10px] font-bold tracking-[-0.02em] uppercase opacity-80 leading-none mb-[3px] whitespace-nowrap"><%= player.given_name %></div>
       <% end %>
-      <div class="<%= name_text %> font-extrabold tracking-[-0.02em] uppercase leading-none whitespace-nowrap"><%= player.display_name %></div>
-      <% if hero? %>
-        <dl class="<%= meta_text %> mt-3 space-y-2 leading-none">
-          <% [ [ "Position", position_label ], [ "Club", team&.name ], [ "Cost", cost ], [ "Ownership", ownership ] ].each do |label, value| %>
-            <% next if value.blank? %>
-            <div>
-              <dt class="text-xs font-bold uppercase tracking-[-0.02em] leading-none opacity-60"><%= label %></dt>
-              <dd class="mt-0.5 font-bold tabular-nums"><%= value %></dd>
-            </div>
-          <% end %>
-        </dl>
-      <% else %>
-        <div class="<%= meta_text %> font-bold opacity-95 leading-none mt-[5px] whitespace-nowrap flex items-center gap-1.5">
-          <% if position_label %>
-            <span><%= position_label %></span>
-            <span class="opacity-50 font-normal">/</span>
-          <% end %>
-          <span><%= team&.short_name %></span>
-          <% if cost %>
-            <span class="opacity-50 font-normal">/</span><span class="tabular-nums"><%= cost %></span>
-          <% end %>
-          <% if ownership %>
-            <span class="opacity-50 font-normal">/</span><span class="tabular-nums"><%= ownership %></span>
-          <% end %>
-        </div>
-      <% end %>
+      <div class="text-[21px] font-extrabold tracking-[-0.02em] uppercase leading-none whitespace-nowrap"><%= player.display_name %></div>
+      <div class="text-[10.5px] font-bold opacity-95 leading-none mt-[5px] whitespace-nowrap flex items-center gap-1.5">
+        <span><%= team&.short_name %></span>
+        <% if cost %>
+          <span class="opacity-50 font-normal">/</span><span class="tabular-nums"><%= cost %></span>
+        <% end %>
+        <% if ownership %>
+          <span class="opacity-50 font-normal">/</span><span class="tabular-nums"><%= ownership %></span>
+        <% end %>
+      </div>
     </div>
 
     <% if player.cutout_url %>
-      <span class="absolute right-6 bottom-0 <%= cutout_height %> z-[2] pointer-events-none">
+      <span class="absolute right-6 bottom-0 h-[100px] z-[2] pointer-events-none">
         <%= image_tag player.cutout_url, alt: "",
               class: "block h-full w-auto object-bottom drop-shadow-[0_5px_9px_rgba(0,0,0,0.22)]",
               onerror: "this.parentElement.remove()" %>
@@ -58,5 +42,5 @@
     <% end %>
   </div>
 
-  <div class="<%= side_width %> shrink-0 flex items-center justify-center <%= corner_text %> font-extrabold tracking-[-0.03em] leading-none text-zinc-900"><%= grade %></div>
+  <div class="w-[54px] shrink-0 flex items-center justify-center text-[32px] font-extrabold tracking-[-0.03em] leading-none text-zinc-900"><%= grade %></div>
 </div>

--- a/app/components/player_hero_component.html.erb
+++ b/app/components/player_hero_component.html.erb
@@ -1,0 +1,37 @@
+<div class="relative h-[260px] sm:h-[280px] lg:h-[300px] overflow-hidden rounded-xl border border-zinc-200 shadow-sm <%= text_class %>"
+     style="background-color: <%= color %>">
+  <% if team&.badge_url %>
+    <span class="pointer-events-none absolute top-1/2 -right-11 z-0 h-[280px] w-[280px] -translate-y-1/2 sm:h-[320px] sm:w-[320px] lg:h-[340px] lg:w-[340px]">
+      <%= image_tag team.badge_url, alt: "", class: "h-full w-full object-contain opacity-20 #{badge_silhouette}" %>
+    </span>
+    <span class="pointer-events-none absolute top-1/2 -right-11 z-0 h-[280px] w-[280px] -translate-y-1/2 sm:h-[320px] sm:w-[320px] lg:h-[340px] lg:w-[340px]">
+      <%= image_tag team.badge_url, alt: "", class: "h-full w-full object-contain opacity-[.22]" %>
+    </span>
+  <% end %>
+
+  <% if player.cutout_url %>
+    <span class="pointer-events-none absolute bottom-0 right-5 z-[1] h-[208px] sm:right-7 sm:h-[248px] lg:h-[276px]">
+      <%= image_tag player.cutout_url, alt: "",
+            class: "block h-full w-auto object-bottom drop-shadow-[0_6px_14px_rgba(0,0,0,0.28)]",
+            onerror: "this.parentElement.remove()" %>
+    </span>
+  <% end %>
+
+  <div class="relative z-[2] flex h-full flex-col justify-center p-5 sm:p-7">
+    <div class="w-[58%] lg:w-auto lg:max-w-[60%]">
+      <% if player.given_name.present? %>
+        <p class="text-xs sm:text-sm font-bold uppercase leading-none tracking-[-0.02em] opacity-80"><%= player.given_name %></p>
+      <% end %>
+      <p class="mt-1 text-3xl sm:text-4xl lg:text-5xl font-extrabold uppercase leading-[0.95] tracking-[-0.02em]"><%= player.display_name %></p>
+
+      <dl class="mt-4 grid grid-cols-[max-content_max-content] gap-x-6 gap-y-3 lg:flex lg:gap-10">
+        <% details.each do |label, value| %>
+          <div>
+            <dt class="text-[10px] font-bold uppercase leading-none tracking-wider opacity-60"><%= label %></dt>
+            <dd class="mt-1 text-sm sm:text-base font-bold leading-none tabular-nums"><%= value %></dd>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+</div>

--- a/app/components/player_hero_component.rb
+++ b/app/components/player_hero_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# The banner at the top of a player's page. It says who he is; the panel beneath
+# it says how he is rated, so no rank or grade appears here.
+class PlayerHeroComponent < PlayerRowComponent
+  def initialize(player:, facts:)
+    super(ranking: nil, player: player, facts: facts)
+  end
+
+  private
+
+  def details
+    [
+      [ "Position", player.position&.capitalize ],
+      [ "Club", team&.name ],
+      [ "Cost", cost ],
+      [ "Ownership", ownership ]
+    ].reject { |_label, value| value.blank? }
+  end
+
+  def badge_silhouette
+    team.on_light? ? "brightness-0" : "brightness-0 invert"
+  end
+end

--- a/app/components/player_row_component.html.erb
+++ b/app/components/player_row_component.html.erb
@@ -27,10 +27,6 @@
           <% end %>
           <span class="row-start-4 self-center leading-none text-2xl font-extrabold tracking-[-0.02em] uppercase whitespace-nowrap"><%= player.display_name %></span>
           <span class="row-start-6 self-start leading-none text-[12.5px] font-bold whitespace-nowrap flex items-center gap-[7px]">
-            <% if position_label %>
-              <span><%= position_label %></span>
-              <span class="opacity-50 font-normal">/</span>
-            <% end %>
             <span><%= team&.name %></span>
             <% if cost %>
               <span class="opacity-50 font-normal">/</span>

--- a/app/components/player_row_component.rb
+++ b/app/components/player_row_component.rb
@@ -1,37 +1,15 @@
 # frozen_string_literal: true
 
 class PlayerRowComponent < ViewComponent::Base
-  def initialize(ranking:, player:, facts:, show_position: false, hero: false)
+  def initialize(ranking:, player:, facts:)
     @ranking = ranking
     @player = player
     @facts = facts || {}
-    @show_position = show_position
-    @hero = hero
   end
 
   private
 
   attr_reader :ranking, :player, :facts
-
-  def hero?
-    @hero
-  end
-
-  def card_height = hero? ? "h-64" : "h-24"
-  def side_width = hero? ? "w-24" : "w-[54px]"
-  def corner_text = hero? ? "text-5xl" : "text-[32px]"
-  def name_text = hero? ? "text-3xl" : "text-[21px]"
-  def given_text = hero? ? "text-xs" : "text-[10px]"
-  def meta_text = hero? ? "text-base" : "text-[10.5px]"
-  def badge_size = hero? ? "h-[220px] w-[220px]" : "h-[120px] w-[120px]"
-  def cutout_height = hero? ? "h-[248px]" : "h-[100px]"
-  def banner_pad = hero? ? "pl-9" : "pl-6"
-
-  def position_label
-    return unless @show_position
-
-    player.position&.capitalize
-  end
 
   def rank
     ranking.bot_rank || "-"

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -150,7 +150,6 @@ class PlayersController < ApplicationController
       gameweek: gameweek,
       opponent: match && (home ? match.away_team : match.home_team),
       home: home,
-      difficulty: match&.difficulty_for(@player.team_id),
       points: points,
       projected: projected
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,14 +51,6 @@ module ApplicationHelper
     format("%.1f%% owned", percent)
   end
 
-  # FPL rates each fixture 1 (easiest) to 5 (hardest). The number means nothing
-  # to a reader, so it is shown as a word.
-  FIXTURE_EASE = { 1 => "Very easy", 2 => "Easy", 3 => "Average", 4 => "Hard", 5 => "Very hard" }.freeze
-
-  def fixture_ease(difficulty)
-    FIXTURE_EASE.fetch(difficulty.to_i, "Unrated")
-  end
-
   private
 
   def structured_data_schema

--- a/app/views/players/_fixture_table.html.erb
+++ b/app/views/players/_fixture_table.html.erb
@@ -1,28 +1,33 @@
 <div>
   <h2 class="text-base/6 font-semibold text-zinc-950"><%= title %></h2>
   <% if rows.any? %>
-    <table class="mt-3 w-full text-sm">
+    <table class="mt-3 w-full table-fixed text-sm">
       <thead>
         <tr class="text-xs uppercase tracking-wide text-zinc-400 text-left">
-          <th class="py-1 font-semibold">GW</th>
-          <th class="py-1 font-semibold">Opponent</th>
-          <th class="py-1 font-semibold">Fixture</th>
-          <th class="py-1 font-semibold text-right"><%= points_label %></th>
+          <%# Three even columns, then just enough room for the number to sit
+              hard right without opening a gap beside the opponent. %>
+          <th class="w-[28%] py-1 font-semibold">GW</th>
+          <th class="w-[28%] py-1 font-semibold">Date</th>
+          <th class="w-[30%] py-1 font-semibold">Opponent</th>
+          <th class="w-[14%] py-1 font-semibold text-right"><%= points_label %></th>
         </tr>
       </thead>
       <tbody>
         <% rows.each do |row| %>
-          <tr class="border-t border-zinc-100">
-            <td class="py-2 whitespace-nowrap text-zinc-500 tabular-nums">
-              GW<%= row[:gameweek].fpl_id %>
-              <% if row[:gameweek].start_time %><span class="block text-xs text-zinc-400"><%= row[:gameweek].start_time.strftime("%-d %b") %></span><% end %>
+          <tr class="border-t border-zinc-100 text-zinc-800">
+            <td class="py-2 whitespace-nowrap tabular-nums">GW<%= row[:gameweek].fpl_id %></td>
+            <td class="py-2 whitespace-nowrap tabular-nums">
+              <% if row[:gameweek].start_time %><%= row[:gameweek].start_time.strftime("%-d %b") %><% else %>—<% end %>
             </td>
-            <td class="py-2 whitespace-nowrap text-zinc-800">
-              <% if row[:opponent] %><%= row[:opponent].short_name || row[:opponent].name %> <span class="text-zinc-400">(<%= row[:home] ? "H" : "A" %>)</span><% else %><span class="text-zinc-400">—</span><% end %>
+            <td class="py-2 whitespace-nowrap">
+              <% if row[:opponent] %>
+                <span class="lg:hidden"><%= row[:opponent].short_name || row[:opponent].name %></span>
+                <span class="hidden lg:inline"><%= row[:opponent].name %></span>
+                <span class="text-zinc-400">(<%= row[:home] ? "H" : "A" %>)</span>
+              <% else %>—<% end %>
             </td>
-            <td class="py-2 whitespace-nowrap text-zinc-500"><%= fixture_ease(row[:difficulty]) %></td>
-            <td class="py-2 text-right tabular-nums font-semibold text-zinc-900">
-              <% if row[:points] %><%= row[:points].is_a?(Integer) ? row[:points] : format("%.1f", row[:points]) %><% else %><span class="text-zinc-400">—</span><% end %>
+            <td class="py-2 text-right tabular-nums font-semibold">
+              <% if row[:points] %><%= row[:points].is_a?(Integer) ? row[:points] : format("%.1f", row[:points]) %><% else %>—<% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -16,21 +16,8 @@
 <div class="mt-6">
   <h1 class="sr-only"><%= @player.full_name %></h1>
 
-  <% if @forecast %>
-    <%= form_with url: player_path(@player), method: :get, class: "mb-3" do %>
-      <div class="inline-flex items-center gap-1 rounded-lg bg-zinc-100 p-1" role="radiogroup">
-        <% [ [ "gameweek", "Next Gameweek" ], [ "season", "Rest of Season" ] ].each do |value, label| %>
-          <% active = @horizon == value %>
-          <label class="px-3 py-1.5 text-sm font-medium rounded-md cursor-pointer transition-colors <%= active ? "bg-white text-zinc-900 shadow-sm" : "text-zinc-500 hover:text-zinc-900" %>">
-            <%= radio_button_tag :horizon, value, active, class: "sr-only", onchange: "this.form.requestSubmit()" %><%= label %>
-          </label>
-        <% end %>
-      </div>
-    <% end %>
-  <% end %>
-
   <% if @player_ranking %>
-    <%= render PlayerCardComponent.new(ranking: @player_ranking, player: @player, facts: @player_facts, show_position: true, hero: true) %>
+    <%= render PlayerHeroComponent.new(player: @player, facts: @player_facts) %>
   <% else %>
     <div class="flex items-start gap-6">
       <%= render PlayerAvatarComponent.new(player: @player, size: :large) %>
@@ -55,19 +42,50 @@
 </div>
 
 <!-- Why this grade -->
-<% if @forecast %>
-  <% season = @forecast[:horizon] == "season" %>
-  <div class="mt-8 rounded-lg bg-zinc-100 p-4">
-    <% if @forecast[:score] %>
-      <p class="text-3xl font-bold text-zinc-950 leading-none">
-        <%= format("%.1f", @forecast[:score]) %>
-        <span class="text-sm font-medium text-zinc-500">expected points <%= season ? "rest of season" : "this gameweek" %></span>
-      </p>
-    <% end %>
-    <% if @forecast[:tier] %>
-      <p class="mt-2 text-sm text-zinc-600"><%= TierCalculator::TIERS.dig(@forecast[:tier], :description) %></p>
-    <% end %>
-  </div>
+<%# The horizon changes nothing above this panel, so only the panel navigates. %>
+<%= turbo_frame_tag "player_forecast", data: { turbo_action: "advance" } do %>
+  <% if @forecast %>
+    <% season = @forecast[:horizon] == "season" %>
+    <div class="mt-4 rounded-xl bg-zinc-100 p-5 sm:p-7">
+      <div class="flex flex-col gap-5 lg:flex-row-reverse lg:items-start lg:justify-between">
+        <%= form_with url: player_path(@player), method: :get, class: "shrink-0" do %>
+          <div class="inline-flex items-center gap-1 rounded-lg bg-zinc-200/70 p-1" role="radiogroup">
+            <% [ [ "gameweek", "Next Gameweek" ], [ "season", "Rest of Season" ] ].each do |value, label| %>
+              <% active = @horizon == value %>
+              <label class="px-3 py-1.5 text-sm font-medium rounded-md cursor-pointer transition-colors <%= active ? "bg-white text-zinc-900 shadow-sm" : "text-zinc-500 hover:text-zinc-900" %>">
+                <%= radio_button_tag :horizon, value, active, class: "sr-only", onchange: "this.form.requestSubmit()" %><%= label %>
+              </label>
+            <% end %>
+          </div>
+        <% end %>
+
+        <dl class="flex flex-wrap items-baseline gap-x-6 gap-y-4 lg:gap-x-10">
+          <% if @forecast[:rank] %>
+            <div>
+              <dt class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Rank</dt>
+              <dd class="mt-1.5 text-3xl font-extrabold leading-none tracking-[-0.03em] tabular-nums text-zinc-950">#<%= @forecast[:rank] %></dd>
+            </div>
+          <% end %>
+          <% if @forecast[:grade] %>
+            <div>
+              <dt class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Grade</dt>
+              <dd class="mt-1.5 text-3xl font-extrabold leading-none tracking-[-0.03em] text-zinc-950"><%= @forecast[:grade] %></dd>
+            </div>
+          <% end %>
+          <% if @forecast[:score] %>
+            <div>
+              <dt class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Expected points <%= season ? "rest of season" : "this gameweek" %></dt>
+              <dd class="mt-1.5 text-3xl font-extrabold leading-none tracking-[-0.03em] tabular-nums text-zinc-950"><%= format("%.1f", @forecast[:score]) %></dd>
+            </div>
+          <% end %>
+        </dl>
+      </div>
+
+      <% if @forecast[:tier] %>
+        <p class="mt-5 text-sm text-zinc-600"><%= TierCalculator::TIERS.dig(@forecast[:tier], :description) %></p>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>
 
 <!-- Fixtures & Form -->

--- a/test/system/player_page_test.rb
+++ b/test/system/player_page_test.rb
@@ -1,0 +1,42 @@
+require "application_system_test_case"
+
+# The horizon toggle used to submit the whole page, which threw the reader back
+# to the top every time they compared a week against the season. Only the
+# forecast panel changes with the horizon, so only that frame navigates.
+class PlayerPageTest < ApplicationSystemTestCase
+  setup do
+    Forecast.destroy_all
+    Gameweek.destroy_all
+    @team = Team.create!(fpl_id: 971, name: "Test City", short_name: "TCY", code: 971)
+    @gameweek = Gameweek.create!(fpl_id: 1, name: "Gameweek 1", start_time: 2.days.from_now, is_next: true)
+    @player = Player.create!(first_name: "Test", last_name: "Keeper", short_name: "T.Keeper",
+                             fpl_id: 9710, code: 9710, team: @team, position: "goalkeeper")
+    Forecast.create!(player: @player, gameweek: @gameweek, rank: 1, score: 5.0, horizon: "gameweek")
+    Forecast.create!(player: @player, gameweek: @gameweek, rank: 3, score: 180.0, horizon: "season")
+  end
+
+  test "switching the horizon rewrites the forecast panel without reloading the page" do
+    visit player_path(@player)
+    assert_text "5.0"
+
+    # Survives a frame navigation; a full page load would wipe it. This, not a
+    # scroll assertion, is what the reader actually feels: the document is never
+    # replaced, so the scroll position is never reset.
+    page.execute_script("document.body.dataset.marker = 'kept'")
+
+    find("label", text: "Rest of Season").click
+
+    assert_text "180.0"
+    assert_no_text "Content missing"
+    assert_equal "kept", page.evaluate_script("document.body.dataset.marker")
+  end
+
+  test "the horizon is in the URL, so the panel survives a refresh" do
+    visit player_path(@player)
+    find("label", text: "Rest of Season").click
+    assert_text "180.0"
+
+    visit current_url
+    assert_text "180.0"
+  end
+end


### PR DESCRIPTION
The player page hero was the rankings card rendered with `hero: true`, and `PlayerRowComponent` carried nine ternaries to serve it (`card_height`, `side_width`, `badge_size`, `cutout_height`, …). Each scaled a fixed-pixel layout up without changing its shape, so at 390px two 96px rank/grade columns left ~150px of banner to hold a 220px badge and a 248px cutout, and the detail list clipped mid-word ("Goalke", "Arse", "£6.").

## The hero

Extracted to `PlayerHeroComponent`, which removes those ternaries from the shared row/card. It drops the rank and grade columns so the colour, crest and player get the full width, and anchors the player hard right at the same inset the name has on the left, crest large behind him.

Breakpoints now turn at `lg` rather than `sm` — the wide-desktop offsets previously applied from 640px, where there is no room for them, which broke the whole 640–1023px range. Name size was chosen against the longest names actually in the data (`Mamardashvili`, unbreakable at 13 characters, and `Borges Rodrigues`, which wraps).

## The forecast panel

Rank, grade and the horizon toggle move down into it, since all three are things the horizon changes. The panel is a turbo frame, so switching horizon rewrites it in place rather than reloading the page and throwing the reader back to the top. Verified in a real browser: `scrollY` held at 400, document never replaced, URL still advanced to `?horizon=season`.

The frame sits *outside* the `if @forecast` guard on purpose — a player can have a gameweek forecast and no season one, and a response with no matching frame renders Turbo's "Content missing".

## Fixture tables

Date column added; opponent spelled out in full from `lg` up, short name below. The difficulty word is gone, since the xP beside it already says the same thing. That left `fixture_ease` / `FIXTURE_EASE` and the row hash's `difficulty:` key with no readers, so both go. Difficulty still drives `ExpectedPoints` and `FixtureProjection` — it just no longer describes itself twice.

Columns are 28/28/30/14 rather than even quarters: a right-aligned number in a 25% column opens a gap next to the opponent, so the number gets a narrow column and the three text columns share the rest.

## Testing

191 unit tests, 4 system tests, RuboCop across 158 files — all green. New `test/system/player_page_test.rb` covers the frame navigation, asserting via a marker on `document.body` that the document is never replaced (that, not a scroll assertion, is the real mechanism — the test page is too short to scroll).

Checked at 390 / 700 / 1280px against a light team colour (Man City), a dark one (Arsenal, Liverpool), the longest names, and a player with no cutout image.

## Known follow-up

A player with no `cutout_url` (e.g. Coventry's Borges Rodrigues) shows the crest at full strength with nothing in front of it, so it reads as the subject rather than a backdrop. Left as-is because those opacities are the established treatment on the rankings rows, where a player is always present. Worth dimming the crest when `cutout_url` is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn3TMxEmQMp1djfwsyQ4QL