### PR TITLE
Charge a keeper for the goals that go past him

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -135,13 +135,21 @@ class PlayersController < ApplicationController
          .order("gameweeks.fpl_id ASC").limit(5).to_a
   end
 
+  # The week's own forecast anchors the run of fixtures, and the season's stands
+  # behind it for a player whose team is not playing this week. See
+  # FixtureProjection#base.
   def project_fixtures(matches)
-    weekly = @next_gameweek && @player.forecasts.weekly.find_by(gameweek: @next_gameweek)
     FixtureProjection.call(
-      player: @player, matches: matches,
-      anchor_score: weekly&.score, anchor_worth: weekly&.working&.dig("games"),
+      player: @player, matches: matches, anchors: anchors,
       next_gameweek_id: @next_gameweek&.id
     ).map { |row| fixture_row(row.match.gameweek, row.match, row.points, row.projected) }
+  end
+
+  def anchors
+    return [] unless @next_gameweek
+
+    forecasts = @player.forecasts.where(gameweek: @next_gameweek).index_by(&:horizon)
+    [ forecasts["gameweek"], forecasts[SEASON] ]
   end
 
   def fixture_row(gameweek, match, points, projected)

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -18,9 +18,11 @@ class ExpectedPoints < ApplicationService
   STAT_TYPES = %w[
     season_minutes last_season_minutes chance_of_playing
     expected_goals_per_90 expected_goal_involvements_per_90 clean_sheets_per_90 saves_per_90
+    expected_goals_conceded_per_90
     selected_by_percent transfers_in transfers_out now_cost form points_per_game season_bonus
     last_season_expected_goals_per_90 last_season_expected_goal_involvements_per_90
     last_season_clean_sheets_per_90 last_season_saves_per_90 last_season_bonus
+    last_season_expected_goals_conceded_per_90
   ].freeze
 
   # Where each measurement is read from before a ball is kicked.
@@ -38,7 +40,8 @@ class ExpectedPoints < ApplicationService
     "expected_goals_per_90" => "last_season_expected_goals_per_90",
     "expected_goal_involvements_per_90" => "last_season_expected_goal_involvements_per_90",
     "clean_sheets_per_90" => "last_season_clean_sheets_per_90",
-    "saves_per_90" => "last_season_saves_per_90"
+    "saves_per_90" => "last_season_saves_per_90",
+    "expected_goals_conceded_per_90" => "last_season_expected_goals_conceded_per_90"
   }.freeze
 
   FULL_MATCH = 90.0
@@ -88,6 +91,13 @@ class ExpectedPoints < ApplicationService
   # FPL's scoring table, by position.
   GOAL = { "goalkeeper" => 10, "defender" => 6, "midfielder" => 5, "forward" => 4 }.freeze
   CLEAN_SHEET = { "goalkeeper" => 4, "defender" => 4, "midfielder" => 1, "forward" => 0 }.freeze
+
+  # The other side of a clean sheet, and a separate rule rather than the same one
+  # read backwards: a keeper or defender loses a point for every second goal his
+  # side concedes, whether or not the sheet was ever going to be clean. Nobody
+  # further up the pitch pays for them.
+  CONCEDED = { "goalkeeper" => 1, "defender" => 1, "midfielder" => 0, "forward" => 0 }.freeze
+
   ASSIST = 3
   SAVES_PER_POINT = 3.0
 
@@ -147,10 +157,30 @@ class ExpectedPoints < ApplicationService
   # a reader can feel.
   ATTACK_STEP = 1.4
 
-  # Saves run the other way, well below one: the afternoon that denies a
-  # goalkeeper his clean sheet is the afternoon that keeps him busy, and pushed
-  # this far it gives a keeper a real reason to prefer the harder game.
-  SAVE_STEP = 0.62
+  # Saves run the other way: the afternoon that denies a goalkeeper his clean
+  # sheet is the afternoon that keeps him busy.
+  #
+  # How much busier is the whole question, and it was answered far too generously.
+  # At 0.62 the cruellest fixture in the game handed a keeper two and a half times
+  # his usual saves, which no goalkeeper has ever managed: the best sides take
+  # something like a third more shots than an ordinary opponent, not twice as
+  # many. The arithmetic then said the same thing every week, because three saves
+  # are worth one point and a clean sheet is worth four: a Bournemouth keeper away
+  # at Man City was the second best pick in the game, ahead of every keeper with
+  # an easy afternoon, purely for the shots he was going to face.
+  #
+  # So the step is back where the shot counts put it. A hard fixture still costs a
+  # keeper less than it costs his defenders, which is the true part of the idea,
+  # and it is still a cost.
+  SAVE_STEP = 0.87
+
+  # Goals conceded run with the opponent rather than against him, so this sits
+  # below one like the saves it comes with. A step of a quarter puts about half
+  # again as many goals past a side facing the champions as facing an ordinary
+  # team, which is roughly what the goal records show. It is deliberately gentler
+  # than the clean sheet step: whether a sheet stays clean at all turns on the
+  # opponent far more than how many goals eventually go past.
+  CONCEDE_STEP = 0.8
 
   # What the crowd is willing to pay for him, and how far we let that speak.
   #
@@ -241,6 +271,7 @@ class ExpectedPoints < ApplicationService
       regular_share: REGULAR_SHARE, unproven_minutes: UNPROVEN_MINUTES,
       form_swing: FORM_SWING, form_swing_growth: FORM_SWING_GROWTH,
       clean_sheet_step: CLEAN_SHEET_STEP, attack_step: ATTACK_STEP, save_step: SAVE_STEP,
+      concede_step: CONCEDE_STEP,
       clamp_width: CLAMP_WIDTH, perf_growth: PERF_GROWTH,
       price_power: PRICE_POWER, price_power_floor: PRICE_POWER_FLOOR,
       new_club_minutes: NEW_CLUB_MINUTES, nailed_on: NAILED_ON, cheapest: CHEAPEST,
@@ -540,6 +571,7 @@ class ExpectedPoints < ApplicationService
     attacking_points(ranking) * swing(ATTACK_STEP, fixture) +
       clean_sheet_points(ranking) * swing(CLEAN_SHEET_STEP, fixture) +
       save_points(ranking) * swing(SAVE_STEP, fixture) +
+      conceded_points(ranking, fixture) +
       bonus_points(ranking)
   end
 
@@ -593,6 +625,77 @@ class ExpectedPoints < ApplicationService
 
   def clean_sheet_points(ranking)
     CLEAN_SHEET.fetch(ranking.position, 0) * record(ranking, "clean_sheets_per_90")
+  end
+
+  # What the goals that go past him cost, which until now was nothing at all: a
+  # keeper at a leaky club was charged for the clean sheets he would not keep and
+  # given the goals themselves for free.
+  #
+  # This one takes the fixture itself rather than being multiplied by a swing
+  # afterwards, because the points do not follow the goals in a straight line and
+  # so cannot be scaled after the fact. See #pairs_of.
+  def conceded_points(ranking, fixture)
+    penalty = CONCEDED.fetch(ranking.position, 0)
+    return 0.0 if penalty.zero?
+
+    -penalty * pairs_of(goals_past_him(ranking, fixture))
+  end
+
+  def goals_past_him(ranking, fixture)
+    conceded_rate(ranking) * swing(CONCEDE_STEP, fixture)
+  end
+
+  # How many goals his side lets in, per 90.
+  #
+  # His own figure first, and his club's where he has none: conceding is something
+  # a team does, so a man signed from abroad concedes at the rate of the defence he
+  # has joined rather than at no rate at all.
+  #
+  # A promoted club has no Premier League record for anybody, and a missing rate
+  # must not read as a defence nobody scores against. Left as nought it handed the
+  # three sides most likely to ship goals the only clean bill in the league, and
+  # floated their defenders up the table for it. So they are judged by the worst
+  # record among the clubs we do have one for, which is roughly where a promoted
+  # side ends up. It is a guess, but it is a guess in the direction the evidence
+  # points, which nought is not.
+  def conceded_rate(ranking)
+    own = record(ranking, "expected_goals_conceded_per_90")
+    return own if own.positive?
+
+    club_rates[ranking.team_id] || worst_club_rate
+  end
+
+  # What each club lets in, taken as the middle of its players' figures so that one
+  # man who played only the afternoons it went wrong cannot speak for the defence.
+  def club_rates
+    @club_rates ||= @rankings.group_by(&:team_id).each_with_object({}) do |(team_id, members), rates|
+      recorded = members.map { |member| record(member, "expected_goals_conceded_per_90") }.select(&:positive?)
+      rates[team_id] = middle_of(recorded) if recorded.any?
+    end
+  end
+
+  def worst_club_rate
+    @worst_club_rate ||= club_rates.values.max.to_f
+  end
+
+  def middle_of(values)
+    values.sort[values.size / 2]
+  end
+
+  # How many whole pairs of goals to expect, since only the second of each pair
+  # costs anybody a point.
+  #
+  # Half the goals is the obvious answer and the wrong one, because the lone goal
+  # in a one-nil defeat is free and half the time a side conceding two ships them
+  # in separate matches. Goals arrive at random and independently, and for
+  # arrivals like that the pairs come out as the goals themselves less the chance
+  # there is an odd one left over. On a side shipping one and a half a game the
+  # difference is a third of a point every week, all of it charged to the clubs
+  # that concede most.
+  def pairs_of(goals)
+    return 0.0 unless goals.positive?
+
+    (goals - (1 - Math.exp(-2 * goals)) / 2) / 2
   end
 
   # Only ever anything for a keeper, so this needs no position of its own.

--- a/app/services/fixture_projection.rb
+++ b/app/services/fixture_projection.rb
@@ -9,11 +9,10 @@
 class FixtureProjection < ApplicationService
   Row = Struct.new(:match, :points, :projected, keyword_init: true)
 
-  def initialize(player:, matches:, anchor_score:, anchor_worth:, next_gameweek_id:)
+  def initialize(player:, matches:, anchors:, next_gameweek_id:)
     @player = player
     @matches = matches
-    @anchor_score = anchor_score
-    @anchor_worth = anchor_worth
+    @anchors = Array(anchors).compact
     @next_gameweek_id = next_gameweek_id
   end
 
@@ -31,10 +30,27 @@ class FixtureProjection < ApplicationService
     (base * engine.fixture_worth(ranking, fixture_for(match))).round(1)
   end
 
+  # What the player is worth on an ordinary fixture, taken from the first anchor
+  # that has a fixture in it: his forecast for the week, divided back out by what
+  # that week's opponents were worth to him.
+  #
+  # A week he does not play is worth nought over nought games, which is a true
+  # statement about that week and no answer at all about the ones after it. Asked
+  # for the only anchor it had, this used to hand back nothing and empty the whole
+  # column, so a blank gameweek hid the run of fixtures exactly when a manager was
+  # looking past it. The rest-of-season forecast spans the football he does play,
+  # so it answers when the week cannot.
   def base
     return @base if defined?(@base)
 
-    @base = @anchor_score && @anchor_worth.to_f.positive? ? @anchor_score / @anchor_worth : nil
+    @base = @anchors.filter_map { |anchor| ordinary_worth(anchor) }.first
+  end
+
+  def ordinary_worth(anchor)
+    games = anchor.working&.dig("games").to_f
+    return nil unless anchor.score && games.positive?
+
+    anchor.score / games
   end
 
   def fixture_for(match)

--- a/app/services/fpl/sync_player_histories.rb
+++ b/app/services/fpl/sync_player_histories.rb
@@ -30,7 +30,8 @@ module Fpl
       "last_season_expected_goals_per_90" => "expected_goals",
       "last_season_expected_goal_involvements_per_90" => "expected_goal_involvements",
       "last_season_clean_sheets_per_90" => "clean_sheets",
-      "last_season_saves_per_90" => "saves"
+      "last_season_saves_per_90" => "saves",
+      "last_season_expected_goals_conceded_per_90" => "expected_goals_conceded"
     }.freeze
 
     MINUTES_IN_A_MATCH = 90.0
@@ -38,7 +39,7 @@ module Fpl
     # What we currently record from a past season. Bump it when that set changes
     # and every player is asked again on the next run, rather than being left with
     # a partial history that nothing notices.
-    RECORD_VERSION = 2.0
+    RECORD_VERSION = 3.0
 
     REQUEST_DELAY = 0.5 # seconds between requests, to stay a polite guest
 

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -124,6 +124,85 @@ class ExpectedPointsTest < ActiveSupport::TestCase
            "and his goalkeeper minds less, because the shots come to him"
   end
 
+  test "the hardest fixture in the game is never a bonus, however many saves it brings" do
+    keeper = regular(clean_sheets: 0.29).merge("last_season_saves_per_90" => 2.87,
+                                               "last_season_expected_goals_conceded_per_90" => 1.49)
+    rankings = [ ranking(1, position: "goalkeeper") ]
+
+    ordinary = forecast(rankings, { 1 => keeper })
+    cruel = forecast(rankings, { 1 => keeper }, fixtures: { 1 => [ fixture(5) ] })
+
+    assert_operator cruel[1][:points], :<, ordinary[1][:points],
+                    "a keeper at a leaky club away at the champions is worth less, not more"
+  end
+
+  test "a keeper is charged for the goals that go past him, not only for the clean sheet he misses" do
+    rankings = [ ranking(1, position: "goalkeeper"), ranking(2, position: "goalkeeper") ]
+    leaky = regular(clean_sheets: 0.25).merge("last_season_expected_goals_conceded_per_90" => 1.60)
+    tight = regular(clean_sheets: 0.25).merge("last_season_expected_goals_conceded_per_90" => 0.70)
+
+    result = forecast(rankings, { 1 => leaky, 2 => tight })
+
+    assert_operator result[2][:points], :>, result[1][:points],
+                    "two keepers who keep sheets alike are still told apart by what gets past them"
+  end
+
+  test "only whole pairs of goals are docked" do
+    rankings = [ ranking(1, position: "defender") ]
+    stats = { 1 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.50) }
+    free = { 1 => regular }
+
+    charged = forecast(rankings, stats)
+    uncharged = forecast(rankings, free)
+
+    lost = uncharged[1][:points] - charged[1][:points]
+    assert_operator lost, :<, 0.75, "charging for every second goal is not charging for half of them"
+    assert_operator lost, :>, 0.35, "but a side shipping one and a half a game does pay for them"
+  end
+
+  test "a defender with no record of his own concedes at the rate of the club he has joined" do
+    rankings = [ ranking(1, position: "defender", team_id: 1), ranking(2, position: "defender", team_id: 1),
+                 ranking(3, position: "defender", team_id: 2), ranking(4, position: "defender", team_id: 2) ]
+    stats = { 1 => regular.merge("last_season_expected_goals_conceded_per_90" => 0.70), 2 => regular,
+              3 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.60), 4 => regular }
+    fixtures = { 1 => [ fixture ], 2 => [ fixture ] }
+
+    result = forecast(rankings, stats, fixtures: fixtures)
+
+    assert_in_delta result[1][:points], result[2][:points], 0.01, "he is judged by the defence he plays in"
+    assert_operator result[2][:points], :>, result[4][:points],
+                    "and a tight defence is still worth more than a leaky one"
+  end
+
+  test "a promoted club with no record at all is judged as the worst defence in the league" do
+    rankings = [ ranking(1, position: "goalkeeper", team_id: 1), ranking(2, position: "goalkeeper", team_id: 2),
+                 ranking(3, position: "goalkeeper", team_id: 3) ]
+    stats = { 1 => regular.merge("last_season_expected_goals_conceded_per_90" => 0.70),
+              2 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.60),
+              3 => regular } # promoted: nobody at the club has a Premier League record
+    fixtures = { 1 => [ fixture ], 2 => [ fixture ], 3 => [ fixture ] }
+
+    result = forecast(rankings, stats, fixtures: fixtures)
+
+    assert_in_delta result[2][:points], result[3][:points], 0.01,
+                    "an unknown defence is charged as the worst we know of, not as a perfect one"
+    assert_operator result[1][:points], :>, result[3][:points],
+                    "so promotion is no longer worth more than keeping goal behind the best defence in the game"
+  end
+
+  test "the goals that go past a defender are nothing to the man in front of him" do
+    rankings = [ ranking(1, position: "midfielder"), ranking(2, position: "forward") ]
+    stats = { 1 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.60),
+              2 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.60) }
+    clean = { 1 => regular, 2 => regular }
+
+    conceding = forecast(rankings, stats)
+    unbothered = forecast(rankings, clean)
+
+    assert_equal unbothered[1][:points], conceding[1][:points], "FPL docks nobody in midfield for them"
+    assert_equal unbothered[2][:points], conceding[2][:points], "nor anybody up front"
+  end
+
   test "a kind fixture is worth most to the defender with the best record of clean sheets" do
     rankings = [ ranking(1, position: "defender"), ranking(2, position: "defender") ]
     stats = { 1 => regular(clean_sheets: 0.50), 2 => regular(clean_sheets: 0.10) }

--- a/test/services/fixture_projection_test.rb
+++ b/test/services/fixture_projection_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class FixtureProjectionTest < ActiveSupport::TestCase
+  setup do
+    @team = Team.create!(fpl_id: 900, name: "Test City", short_name: "TCY", code: 900)
+    @opponent = Team.create!(fpl_id: 901, name: "Test Rovers", short_name: "TRV", code: 901)
+    @next_gameweek = Gameweek.create!(fpl_id: 90, name: "Gameweek 90", start_time: 2.days.from_now, is_next: true)
+    @later = Gameweek.create!(fpl_id: 91, name: "Gameweek 91", start_time: 9.days.from_now)
+    @player = Player.create!(first_name: "Test", last_name: "Keeper", short_name: "TK",
+                             fpl_id: 9100, code: 9100, team: @team, position: "goalkeeper")
+    {
+      "last_season_minutes" => 3000.0, "last_season_saves_per_90" => 3.0,
+      "last_season_clean_sheets_per_90" => 0.3, "selected_by_percent" => 5.0, "now_cost" => 50.0
+    }.each { |type, value| Statistic.create!(player: @player, gameweek: @next_gameweek, type: type, value: value) }
+    @match = Match.create!(gameweek: @later, home_team: @team, away_team: @opponent,
+                           fpl_id: 9001, home_difficulty: 2, away_difficulty: 4)
+  end
+
+  def anchor(score, games)
+    Forecast.new(player: @player, gameweek: @next_gameweek, score: score, working: { "games" => games })
+  end
+
+  def project(anchors)
+    FixtureProjection.call(player: @player, matches: [ @match ], anchors: anchors,
+                           next_gameweek_id: @next_gameweek.id)
+  end
+
+  test "a run of fixtures is projected from the week's own forecast" do
+    rows = project([ anchor(4.4, 1.1), anchor(150.0, 38.0) ])
+
+    assert rows.first.points.positive?
+    assert rows.first.projected, "a later gameweek is a projection, not a forecast"
+  end
+
+  test "a team blanking this week still shows what the fixtures after it are worth" do
+    blank = anchor(0.0, 0.0)
+
+    assert_nil project([ blank ]).first.points, "there is nothing in a blank week to anchor to"
+    assert project([ blank, anchor(150.0, 38.0) ]).first.points.positive?,
+           "so the season, which spans the football he does play, answers instead"
+  end
+
+  test "a player with nothing forecast at all is left blank rather than guessed at" do
+    assert_nil project([]).first.points
+    assert_nil project([ anchor(nil, 1.0) ]).first.points
+  end
+end


### PR DESCRIPTION
A Bournemouth keeper away at Man City was the second best pick in the game, ahead of every keeper with a kind afternoon. The model meant it: the hardest fixture on the board was worth 16% more to him than an ordinary one.

## What was wrong

Two things, compounding:

- **`SAVE_STEP = 0.62`** said the cruellest fixture hands a keeper two and a half times his usual saves. The best sides take something like a third more shots than an ordinary opponent, not twice as many.
- **Conceding cost nobody anything.** FPL docks a keeper or defender a point for every second goal his side lets in. `expected_goals_conceded_per_90` was already synced and stored, and nothing read it.

So a hard fixture hit a keeper once for the clean sheet he would not keep, and paid him twice over for the shots, when it should have hit him twice.

## What changed

- Save step back to 0.87, where the shot counts put it. A hard fixture still costs a keeper less than it costs his defenders, which is the true part of the idea, and it is still a cost.
- Goals conceded charged for keepers and defenders, moved by the fixture at a gentler step than clean sheets.
- **Whole pairs only.** The lone goal in a one-nil is free, and half the time a side conceding two ships them in separate matches. Reading it as half of every goal is about a third of a point a week too harsh on exactly the clubs this is meant to price.
- **A missing rate is not a clean sheet.** FPL publishes per-90 rates only for Premier League seasons, so Coventry, Hull and Ipswich have no record for anybody. Left at nought it would have handed the three defences most likely to ship goals the only clean bill in the league. His own figure first, his club's where he has none, the worst club we do have a record for where his club has none at all.
- Separate commit: a blank gameweek no longer empties the whole upcoming-fixtures column on the player page. It falls back to the season forecast, which spans the football he does play.

## Effect, real GW1 data

| position | ranked | move 5+ places | top ten unchanged |
|---|---|---|---|
| goalkeeper | 62 | 1 | 9/10 |
| defender | 184 | 14 | 10/10 |
| midfielder | 245 | 0 | 10/10 |
| forward | 68 | 0 | 10/10 |

Petrović 2nd to 16th, out of the grades. Guéhi's City defence clears Forest and Sunderland. Arsenal's back line barely moves. Midfielders and forwards do not move at all, which is the control group: they neither make saves nor pay for goals conceded.

## Before it deploys

`RECORD_VERSION` goes to 3.0, so `SyncPlayerHistories` re-asks FPL for every player at 0.5s each inside a 3 minute budget, roughly two hourly runs. Until it finishes, some players are charged and some are not. Worth running by hand first if a half-applied table matters.

## Still open, deliberately not here

- `defensive_contribution_per_90` is synced and unread, a whole scoring category missing for every position. It is a threshold (10+ as a defender, 12+ further up), not a rate, so it needs its own model.
- `CLEAN_SHEET_STEP` (1.3 to 1.75) and `ATTACK_STEP` (1.1 to 1.4) changed in the same #108 commit that steepened the save step, and are still unvalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138XYZYshV5yABvnj7R5p2x