### PR TITLE
Count the defending, and read the right season

### DIFF
--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -18,11 +18,11 @@ class ExpectedPoints < ApplicationService
   STAT_TYPES = %w[
     season_minutes last_season_minutes chance_of_playing
     expected_goals_per_90 expected_goal_involvements_per_90 clean_sheets_per_90 saves_per_90
-    expected_goals_conceded_per_90
+    expected_goals_conceded_per_90 defensive_contribution_per_90
     selected_by_percent transfers_in transfers_out now_cost form points_per_game season_bonus
     last_season_expected_goals_per_90 last_season_expected_goal_involvements_per_90
     last_season_clean_sheets_per_90 last_season_saves_per_90 last_season_bonus
-    last_season_expected_goals_conceded_per_90
+    last_season_expected_goals_conceded_per_90 last_season_defensive_contribution_per_90
   ].freeze
 
   # Where each measurement is read from before a ball is kicked.
@@ -41,7 +41,8 @@ class ExpectedPoints < ApplicationService
     "expected_goal_involvements_per_90" => "last_season_expected_goal_involvements_per_90",
     "clean_sheets_per_90" => "last_season_clean_sheets_per_90",
     "saves_per_90" => "last_season_saves_per_90",
-    "expected_goals_conceded_per_90" => "last_season_expected_goals_conceded_per_90"
+    "expected_goals_conceded_per_90" => "last_season_expected_goals_conceded_per_90",
+    "defensive_contribution_per_90" => "last_season_defensive_contribution_per_90"
   }.freeze
 
   FULL_MATCH = 90.0
@@ -97,6 +98,18 @@ class ExpectedPoints < ApplicationService
   # side concedes, whether or not the sheet was ever going to be clean. Nobody
   # further up the pitch pays for them.
   CONCEDED = { "goalkeeper" => 1, "defender" => 1, "midfielder" => 0, "forward" => 0 }.freeze
+
+  # The other half of the scoring table, and the only part of it that is not paid
+  # by the goal: two points for clearing a bar of defensive actions in a single
+  # match, ten of them at the back and twelve further up, where a player has to
+  # win the ball back rather than merely be near it. Goalkeepers are not paid for
+  # it at all.
+  DEFENSIVE_POINTS = 2.0
+  DEFENSIVE_ACTIONS = { "defender" => 10, "midfielder" => 12, "forward" => 12 }.freeze
+
+  # How many players a club needs before its own figure is worth more than what
+  # we would otherwise assume of it. See #club_rates.
+  CLUB_EVIDENCE = 3
 
   ASSIST = 3
   SAVES_PER_POINT = 3.0
@@ -181,6 +194,13 @@ class ExpectedPoints < ApplicationService
   # than the clean sheet step: whether a sheet stays clean at all turns on the
   # opponent far more than how many goals eventually go past.
   CONCEDE_STEP = 0.8
+
+  # Defending runs with the opponent, like a goalkeeper's saves: the better the
+  # side in front of you, the more there is to do. Gently, though, because how
+  # much a team defends is mostly a matter of how it plays rather than who it is
+  # playing, and the tables bear that out: the busiest defensive sides in the
+  # league are mid-table, not the worst in it.
+  DEFENSIVE_STEP = 0.9
 
   # What the crowd is willing to pay for him, and how far we let that speak.
   #
@@ -271,7 +291,7 @@ class ExpectedPoints < ApplicationService
       regular_share: REGULAR_SHARE, unproven_minutes: UNPROVEN_MINUTES,
       form_swing: FORM_SWING, form_swing_growth: FORM_SWING_GROWTH,
       clean_sheet_step: CLEAN_SHEET_STEP, attack_step: ATTACK_STEP, save_step: SAVE_STEP,
-      concede_step: CONCEDE_STEP,
+      concede_step: CONCEDE_STEP, defensive_step: DEFENSIVE_STEP, club_evidence: CLUB_EVIDENCE,
       clamp_width: CLAMP_WIDTH, perf_growth: PERF_GROWTH,
       price_power: PRICE_POWER, price_power_floor: PRICE_POWER_FLOOR,
       new_club_minutes: NEW_CLUB_MINUTES, nailed_on: NAILED_ON, cheapest: CHEAPEST,
@@ -572,6 +592,7 @@ class ExpectedPoints < ApplicationService
       clean_sheet_points(ranking) * swing(CLEAN_SHEET_STEP, fixture) +
       save_points(ranking) * swing(SAVE_STEP, fixture) +
       conceded_points(ranking, fixture) +
+      defensive_points(ranking, fixture) +
       bonus_points(ranking)
   end
 
@@ -642,44 +663,93 @@ class ExpectedPoints < ApplicationService
   end
 
   def goals_past_him(ranking, fixture)
-    conceded_rate(ranking) * swing(CONCEDE_STEP, fixture)
+    conceded = club_figure(ranking, "expected_goals_conceded_per_90", if_promoted: :the_worst_in_the_league)
+    conceded * swing(CONCEDE_STEP, fixture)
   end
 
-  # How many goals his side lets in, per 90.
+  # What a club's players do, where the man himself has no record of doing it.
   #
-  # His own figure first, and his club's where he has none: conceding is something
-  # a team does, so a man signed from abroad concedes at the rate of the defence he
-  # has joined rather than at no rate at all.
+  # His own figure first, and his club's where he has none: conceding and
+  # defending are things a side does together, so a man signed from abroad takes
+  # the rate of the defence he has joined rather than no rate at all.
   #
-  # A promoted club has no Premier League record for anybody, and a missing rate
-  # must not read as a defence nobody scores against. Left as nought it handed the
-  # three sides most likely to ship goals the only clean bill in the league, and
-  # floated their defenders up the table for it. So they are judged by the worst
-  # record among the clubs we do have one for, which is roughly where a promoted
-  # side ends up. It is a guess, but it is a guess in the direction the evidence
-  # points, which nought is not.
-  def conceded_rate(ranking)
-    own = record(ranking, "expected_goals_conceded_per_90")
+  # A promoted club has no record for anybody, and what to assume of them depends
+  # entirely on the measurement. They concede more than anyone, so an unknown
+  # defence is charged the worst we know of; left at nought it handed the sides
+  # most likely to ship goals the only clean bill in the league. They do not,
+  # however, defend any more than the rest. Sunderland and Leeds came up a year
+  # ago and make 8.4 defensive actions a game against a league middle of 8.2,
+  # while the top of that table is Everton and Newcastle, both long established.
+  # So an unknown club is ordinary there, and reaching for the highest figure
+  # because it worked for goals would hand players nobody has seen the best rate
+  # in the league.
+  def club_figure(ranking, type, if_promoted:)
+    own = record(ranking, type)
     return own if own.positive?
 
-    club_rates[ranking.team_id] || worst_club_rate
+    club_rates(type)[ranking.team_id] || unknown_club(type, if_promoted)
   end
 
-  # What each club lets in, taken as the middle of its players' figures so that one
-  # man who played only the afternoons it went wrong cannot speak for the defence.
-  def club_rates
-    @club_rates ||= @rankings.group_by(&:team_id).each_with_object({}) do |(team_id, members), rates|
-      recorded = members.map { |member| record(member, "expected_goals_conceded_per_90") }.select(&:positive?)
-      rates[team_id] = middle_of(recorded) if recorded.any?
+  # What each club does, taken as the middle of its players' figures so that one
+  # man who played only the afternoons it went wrong cannot speak for the side.
+  #
+  # A club needs a few of them before its own figure beats the assumption. Ipswich
+  # had exactly one defender with a conceded rate and the whole squad was
+  # inheriting his, which is one man's record wearing a club's name.
+  def club_rates(type)
+    @club_rates ||= {}
+    @club_rates[type] ||= @rankings.group_by(&:team_id).each_with_object({}) do |(team_id, members), rates|
+      recorded = members.map { |member| record(member, type) }.select(&:positive?)
+      rates[team_id] = middle_of(recorded) if recorded.size >= CLUB_EVIDENCE
     end
   end
 
-  def worst_club_rate
-    @worst_club_rate ||= club_rates.values.max.to_f
+  def unknown_club(type, assumption)
+    figures = club_rates(type).values
+    return 0.0 if figures.empty?
+
+    assumption == :the_worst_in_the_league ? figures.max : middle_of(figures)
   end
 
   def middle_of(values)
     values.sort[values.size / 2]
+  end
+
+  # THE DEFENDING, which is not a rate however FPL publishes it.
+  #
+  # Two points for clearing a bar in a single match, so what matters is how often
+  # he clears it rather than what he averages, and the two are nothing alike. A
+  # defender averaging six actions clears ten in about one match in twelve; at
+  # nine it is two in five; at eleven it is two in three. Multiplying the average
+  # by anything at all prices those three the same way, which is why this is the
+  # one part of the scoring table that cannot be read straight off a per-90 rate.
+  #
+  # Nor can a threshold be scaled by minutes afterwards, because half a match is
+  # far less than half a chance of ten actions. So it is worked out over the
+  # minutes he actually plays and then divided back out by them: everything here
+  # is multiplied by his minutes later, and this way what survives that is the
+  # figure calculated here.
+  def defensive_points(ranking, fixture)
+    bar = DEFENSIVE_ACTIONS[ranking.position]
+    share = minutes_share(ranking).to_f
+    return 0.0 if bar.nil? || !share.positive?
+
+    actions = club_figure(ranking, "defensive_contribution_per_90", if_promoted: :an_ordinary_side)
+    DEFENSIVE_POINTS * chance_of_clearing(actions * share * swing(DEFENSIVE_STEP, fixture), bar) / share
+  end
+
+  # How often a count averaging this much comes out at the bar or above, for
+  # actions arriving independently through a match.
+  def chance_of_clearing(expected, bar)
+    return 0.0 unless expected.positive?
+
+    term = Math.exp(-expected)
+    below = term
+    (1...bar).each do |count|
+      term *= expected / count
+      below += term
+    end
+    [ 1 - below, 0.0 ].max
   end
 
   # How many whole pairs of goals to expect, since only the second of each pair

--- a/app/services/fpl/sync_player_histories.rb
+++ b/app/services/fpl/sync_player_histories.rb
@@ -31,15 +31,31 @@ module Fpl
       "last_season_expected_goal_involvements_per_90" => "expected_goal_involvements",
       "last_season_clean_sheets_per_90" => "clean_sheets",
       "last_season_saves_per_90" => "saves",
-      "last_season_expected_goals_conceded_per_90" => "expected_goals_conceded"
+      "last_season_expected_goals_conceded_per_90" => "expected_goals_conceded",
+      "last_season_defensive_contribution_per_90" => "defensive_contribution"
     }.freeze
+
+    # Which season counts as last season, and nothing else does.
+    #
+    # FPL only lists the seasons a player spent in this division, so the most
+    # recent entry is not necessarily the most recent season: a man promoted with
+    # Hull last played here in 2020/21, and one at Coventry in 2015/16. Read as
+    # last season's, an old campaign makes a nailed-on starter of a player nobody
+    # has seen in this league for six years, and a clean sheet rate of one out of
+    # a single match played eleven years ago.
+    #
+    # A season runs August to May, so a date in the second half of the year
+    # belongs to the campaign starting that year and anything earlier to the one
+    # before it. Taken from the gameweek being synced rather than from today, so
+    # the answer is the same whenever it is asked.
+    SEASON_STARTS = 7
 
     MINUTES_IN_A_MATCH = 90.0
 
     # What we currently record from a past season. Bump it when that set changes
     # and every player is asked again on the next run, rather than being left with
     # a partial history that nothing notices.
-    RECORD_VERSION = 3.0
+    RECORD_VERSION = 4.0
 
     REQUEST_DELAY = 0.5 # seconds between requests, to stay a polite guest
 
@@ -114,13 +130,24 @@ module Fpl
 
     def player_records(player, gameweek)
       sleep(@delay) if @delay.positive?
-      now = Time.current
-      season = latest_past_season(player)
-      return [ checked_record(player, gameweek, now) ] if season.nil?
+      summary = fetch_summary(player.fpl_id)
+      # Nobody answered, which is not the same as an answer of none. Left
+      # unreceipted so the next run asks again rather than recording a silence.
+      return [] if summary.nil?
 
+      season = last_season_in(summary, gameweek)
+      return nothing_worth_keeping(player, gameweek) if season.nil?
+
+      now = Time.current
       totals(player, gameweek, season, now) +
-        rates(player, gameweek, season, now) +
-        [ checked_record(player, gameweek, now) ]
+        rates(player, gameweek, season, now) + [ checked_record(player, gameweek, now) ]
+    end
+
+    # No season of his that we would read, so whatever we hold from an older one
+    # goes, and a receipt is left so he is not asked again every hour.
+    def nothing_worth_keeping(player, gameweek)
+      forget_old_seasons(player, gameweek)
+      [ checked_record(player, gameweek, Time.current) ]
     end
 
     # A receipt that we asked, so a player with no past is not asked about again.
@@ -156,10 +183,29 @@ module Fpl
         value: value, created_at: now, updated_at: now }
     end
 
-    # history_past runs oldest first, so the most recent season is last.
-    def latest_past_season(player)
-      summary = fetch_summary(player.fpl_id)
-      summary && summary["history_past"]&.last
+    # history_past runs oldest first, so the most recent season is last. It is
+    # only last season's if it says so. See SEASON_STARTS.
+    def last_season_in(summary, gameweek)
+      season = summary["history_past"]&.last
+      return nil unless season && season["season_name"] == last_season_name(gameweek)
+
+      season
+    end
+
+    def last_season_name(gameweek)
+      played = gameweek.start_time
+      current = played.month < SEASON_STARTS ? played.year - 1 : played.year
+      "#{current - 1}/#{format('%02d', current % 100)}"
+    end
+
+    # A record we have decided not to trust has to go, or the campaign this run
+    # rejected stays in circulation and the forecast keeps reading it.
+    def forget_old_seasons(player, gameweek)
+      Statistic.where(player_id: player.id, gameweek_id: gameweek.id, type: season_types).delete_all
+    end
+
+    def season_types
+      @season_types ||= STAT_TYPES.keys + RATE_TYPES.keys
     end
 
     def fetch_summary(fpl_id)

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -161,32 +161,106 @@ class ExpectedPointsTest < ActiveSupport::TestCase
   end
 
   test "a defender with no record of his own concedes at the rate of the club he has joined" do
-    rankings = [ ranking(1, position: "defender", team_id: 1), ranking(2, position: "defender", team_id: 1),
-                 ranking(3, position: "defender", team_id: 2), ranking(4, position: "defender", team_id: 2) ]
-    stats = { 1 => regular.merge("last_season_expected_goals_conceded_per_90" => 0.70), 2 => regular,
-              3 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.60), 4 => regular }
+    tight = (1..3).map { |id| ranking(id, position: "defender", team_id: 1) }
+    leaky = (5..7).map { |id| ranking(id, position: "defender", team_id: 2) }
+    newcomers = [ ranking(4, position: "defender", team_id: 1), ranking(8, position: "defender", team_id: 2) ]
+    stats = (1..3).index_with { regular.merge("last_season_expected_goals_conceded_per_90" => 0.70) }
+                  .merge((5..7).index_with { regular.merge("last_season_expected_goals_conceded_per_90" => 1.60) })
+                  .merge(4 => regular, 8 => regular)
+    fixtures = { 1 => [ fixture ], 2 => [ fixture ] }
+
+    result = forecast(tight + leaky + newcomers, stats, fixtures: fixtures)
+
+    assert_in_delta result[1][:points], result[4][:points], 0.01, "he is judged by the defence he plays in"
+    assert_operator result[4][:points], :>, result[8][:points],
+                    "and a tight defence is still worth more than a leaky one"
+  end
+
+  # Ten actions in a match is a bar, not a rate, and the difference is the whole
+  # point: the same three extra actions a game are worth almost nothing to a
+  # player who will not reach it, a great deal to one it carries over the line,
+  # and little again to one already clearing it most weeks.
+  test "defensive contribution is how often he clears the bar, not what he averages" do
+    actions = [ 3.0, 6.0, 9.0, 12.0, 15.0 ]
+    rankings = actions.each_index.map { |i| ranking(i + 1, position: "defender") }
+    stats = actions.each_with_index.to_h { |rate, i| [ i + 1, regular.merge("last_season_defensive_contribution_per_90" => rate) ] }
+
+    result = forecast(rankings, stats)
+    steps = (1..4).map { |i| result[i + 1][:points] - result[i][:points] }
+
+    assert_operator steps[0], :<, steps[1], "out of reach is out of reach, however close he gets"
+    assert_operator steps[3], :<, steps[2], "and there is little left to win once he clears it most weeks"
+    assert_operator steps[1], :>, 0.3, "while over the line itself is worth real points"
+  end
+
+  test "a bar is cleared over the minutes he plays, not scaled down after the fact" do
+    rankings = [ ranking(1, position: "defender"), ranking(2, position: "defender") ]
+    full = regular(minutes: 3000.0).merge("last_season_defensive_contribution_per_90" => 9.0)
+    half = regular(minutes: 1200.0).merge("last_season_defensive_contribution_per_90" => 9.0)
+
+    result = forecast(rankings, { 1 => full, 2 => half })
+    ratio = result[2][:points] / result[1][:points]
+
+    assert_operator ratio, :<, result[2][:working][:minutes] / result[1][:working][:minutes].to_f,
+                    "half a match is far less than half a chance of ten actions"
+  end
+
+  test "a goalkeeper is not paid for defending, however much of it he does" do
+    rankings = [ ranking(1, position: "goalkeeper"), ranking(2, position: "goalkeeper") ]
+    stats = { 1 => regular.merge("last_season_defensive_contribution_per_90" => 12.0), 2 => regular }
+
+    result = forecast(rankings, stats)
+
+    assert_in_delta result[1][:points], result[2][:points], 0.01, "FPL pays a keeper nothing for it"
+  end
+
+  # Promoted sides concede more than anybody, so an unknown defence is charged the
+  # worst in the league. They do not defend any more than anybody, so the same
+  # reasoning must not be carried across to this.
+  test "a club nobody has a record for defends like an ordinary side, not like the busiest" do
+    clubs = { 1 => 11.0, 2 => 8.0, 3 => 5.0 }
+    rankings = clubs.keys.flat_map { |team| (1..3).map { |n| ranking(team * 10 + n, position: "defender", team_id: team) } }
+    promoted = ranking(99, position: "defender", team_id: 4)
+    stats = rankings.to_h do |member|
+      [ member.player_id, regular.merge("last_season_defensive_contribution_per_90" => clubs[member.team_id]) ]
+    end.merge(99 => regular)
+    fixtures = (1..4).index_with { [ fixture ] }
+
+    result = forecast(rankings + [ promoted ], stats, fixtures: fixtures)
+
+    assert_operator result[99][:points], :<, result[11][:points],
+                    "a club we have never seen must not inherit the best defensive record in the league"
+    assert_operator result[99][:points], :>, result[31][:points], "nor the worst"
+    assert_in_delta result[21][:points], result[99][:points], 0.01, "it defends like the middle of the league"
+  end
+
+  test "one man's record does not become his club's" do
+    rankings = (1..4).map { |id| ranking(id, position: "defender", team_id: 1) } +
+               [ ranking(5, position: "defender", team_id: 2), ranking(6, position: "defender", team_id: 2) ]
+    stats = (1..4).index_with { regular.merge("last_season_expected_goals_conceded_per_90" => 1.60) }
+                  .merge(5 => regular.merge("last_season_expected_goals_conceded_per_90" => 0.70), 6 => regular)
     fixtures = { 1 => [ fixture ], 2 => [ fixture ] }
 
     result = forecast(rankings, stats, fixtures: fixtures)
 
-    assert_in_delta result[1][:points], result[2][:points], 0.01, "he is judged by the defence he plays in"
-    assert_operator result[2][:points], :>, result[4][:points],
-                    "and a tight defence is still worth more than a leaky one"
+    assert_operator result[6][:points], :<, result[5][:points],
+                    "one team-mate with a record is not a club's record, so his club is judged as unknown"
   end
 
   test "a promoted club with no record at all is judged as the worst defence in the league" do
-    rankings = [ ranking(1, position: "goalkeeper", team_id: 1), ranking(2, position: "goalkeeper", team_id: 2),
-                 ranking(3, position: "goalkeeper", team_id: 3) ]
-    stats = { 1 => regular.merge("last_season_expected_goals_conceded_per_90" => 0.70),
-              2 => regular.merge("last_season_expected_goals_conceded_per_90" => 1.60),
-              3 => regular } # promoted: nobody at the club has a Premier League record
+    tight = (1..3).map { |id| ranking(id, position: "goalkeeper", team_id: 1) }
+    leaky = (4..6).map { |id| ranking(id, position: "goalkeeper", team_id: 2) }
+    promoted = ranking(7, position: "goalkeeper", team_id: 3)
+    stats = (1..3).index_with { regular.merge("last_season_expected_goals_conceded_per_90" => 0.70) }
+                  .merge((4..6).index_with { regular.merge("last_season_expected_goals_conceded_per_90" => 1.60) })
+                  .merge(7 => regular) # promoted: nobody at the club has a Premier League record
     fixtures = { 1 => [ fixture ], 2 => [ fixture ], 3 => [ fixture ] }
 
-    result = forecast(rankings, stats, fixtures: fixtures)
+    result = forecast(tight + leaky + [ promoted ], stats, fixtures: fixtures)
 
-    assert_in_delta result[2][:points], result[3][:points], 0.01,
+    assert_in_delta result[4][:points], result[7][:points], 0.01,
                     "an unknown defence is charged as the worst we know of, not as a perfect one"
-    assert_operator result[1][:points], :>, result[3][:points],
+    assert_operator result[1][:points], :>, result[7][:points],
                     "so promotion is no longer worth more than keeping goal behind the best defence in the game"
   end
 

--- a/test/services/fpl/sync_player_histories_test.rb
+++ b/test/services/fpl/sync_player_histories_test.rb
@@ -2,9 +2,16 @@ require "test_helper"
 require "webmock/minitest"
 
 class Fpl::SyncPlayerHistoriesTest < ActiveSupport::TestCase
+  # The season just gone, for a gameweek played in August 2026. Pinned so the
+  # tests say which season they mean rather than working it out the way the code
+  # does and agreeing with itself.
+  LAST_SEASON = "2025/26".freeze
+  OLD_SEASON = "2020/21".freeze
+
   def setup
     WebMock.disable_net_connect!(allow_localhost: true)
     @gameweek = gameweeks(:next_gw)
+    @gameweek.update!(start_time: Time.utc(2026, 8, 15), end_time: Time.utc(2026, 8, 17))
   end
 
   def teardown
@@ -31,7 +38,7 @@ class Fpl::SyncPlayerHistoriesTest < ActiveSupport::TestCase
 
   test "a run cut short keeps what it collected, and the next one carries on" do
     crowd_of_players(30)
-    stub_every_player([ { "season_name" => "2024/25", "total_points" => 100, "minutes" => 2000 } ])
+    stub_every_player([ { "season_name" => LAST_SEASON, "total_points" => 100, "minutes" => 2000 } ])
 
     Fpl::SyncPlayerHistories.call(delay: 0, budget: 0) # stops after the first batch
     stored = Statistic.where(gameweek: @gameweek, type: "last_season_points").count
@@ -56,7 +63,7 @@ class Fpl::SyncPlayerHistoriesTest < ActiveSupport::TestCase
   end
 
   test "stores last season's totals against the upcoming gameweek" do
-    stub_every_player([ { "season_name" => "2024/25", "total_points" => 150, "minutes" => 2700 } ])
+    stub_every_player([ { "season_name" => LAST_SEASON, "total_points" => 150, "minutes" => 2700 } ])
 
     Fpl::SyncPlayerHistories.call(delay: 0)
 
@@ -67,8 +74,8 @@ class Fpl::SyncPlayerHistoriesTest < ActiveSupport::TestCase
 
   test "takes the most recent season when a player has several" do
     stub_every_player([
-      { "season_name" => "2023/24", "total_points" => 90, "minutes" => 1800 },
-      { "season_name" => "2024/25", "total_points" => 210, "minutes" => 3200 }
+      { "season_name" => "2024/25", "total_points" => 90, "minutes" => 1800 },
+      { "season_name" => LAST_SEASON, "total_points" => 210, "minutes" => 3200 }
     ])
 
     Fpl::SyncPlayerHistories.call(delay: 0)
@@ -77,7 +84,7 @@ class Fpl::SyncPlayerHistoriesTest < ActiveSupport::TestCase
   end
 
   test "skips players already synced so a re-run costs nothing" do
-    stub_every_player([ { "season_name" => "2024/25", "total_points" => 150, "minutes" => 2700 } ])
+    stub_every_player([ { "season_name" => LAST_SEASON, "total_points" => 150, "minutes" => 2700 } ])
     Fpl::SyncPlayerHistories.call(delay: 0)
     WebMock.reset!
 
@@ -91,5 +98,42 @@ class Fpl::SyncPlayerHistoriesTest < ActiveSupport::TestCase
     Fpl::SyncPlayerHistories.call(delay: 0)
 
     assert_nil Statistic.find_by(player: players(:midfielder), type: "last_season_points")
+  end
+
+  # A promoted club's squad is full of these: the last time FPL saw them was
+  # years ago, and read as last season it makes a regular of a man nobody in this
+  # division has picked since.
+  test "a season that is not last season is not last season's record" do
+    stub_every_player([ { "season_name" => OLD_SEASON, "total_points" => 150, "minutes" => 2700 } ])
+
+    Fpl::SyncPlayerHistories.call(delay: 0)
+    player = players(:midfielder)
+
+    assert_nil Statistic.find_by(player: player, gameweek: @gameweek, type: "last_season_minutes"),
+               "six years ago is not evidence about this season's team sheet"
+    assert Statistic.exists?(player: player, gameweek: @gameweek, type: Fpl::SyncPlayerHistories::CHECKED),
+           "and we should not ask again every hour to be told the same thing"
+  end
+
+  test "an old season already stored is cleared once we know better" do
+    player = players(:midfielder)
+    Statistic.create!(player: player, gameweek: @gameweek, type: "last_season_minutes", value: 2700)
+    stub_every_player([ { "season_name" => OLD_SEASON, "total_points" => 150, "minutes" => 2700 } ])
+
+    Fpl::SyncPlayerHistories.call(delay: 0)
+
+    assert_nil Statistic.find_by(player: player, gameweek: @gameweek, type: "last_season_minutes"),
+               "a record this run has rejected must not stay in circulation"
+  end
+
+  test "a player we could not reach is asked again rather than recorded as having no past" do
+    Player.pluck(:fpl_id).each do |fpl_id|
+      stub_request(:get, "https://fantasy.premierleague.com/api/element-summary/#{fpl_id}/").to_return(status: 503)
+    end
+
+    Fpl::SyncPlayerHistories.call(delay: 0)
+
+    assert_not Statistic.exists?(gameweek: @gameweek, type: Fpl::SyncPlayerHistories::CHECKED),
+               "nobody answered, which is not the same as an answer of none"
   end
 end


### PR DESCRIPTION
Three changes that belong together: the largest missing piece of the scoring table, and the two input problems that would have made it wrong for promoted clubs.

## 1. Defensive contribution

Two points for 10 defensive actions in a match, 12 for midfielders and forwards, scored as nought until now. `defensive_contribution_per_90` was already synced and unread. Rice averages 10.9 a game, roughly 0.8 points a week we were not counting.

**It is a bar, not a rate, and the two behave nothing alike.** A defender averaging 6 clears 10 in about one match in twelve; at 9 it is two in five; at 11 it is two in three. Any multiplication of the average prices all three the same. This asks how often he clears it.

**A bar cannot be scaled by minutes afterwards** either, because half a match is far less than half a chance of ten actions. It is worked out over the minutes he actually plays, then divided back out by them, so the figure that survives the model's own multiplication is the one calculated here.

## 2. An old season was being read as last season

FPL lists only the seasons a player spent in this division, so his most recent entry is not necessarily the most recent season. Of the twelve Coventry and Hull players carrying a record, **two** are genuinely from last season:

| player | club | season we called "last season" |
|---|---|---|
| Ajayi | HUL | 2020/21, and its 2779 minutes made him a nailed-on starter |
| Grimes | COV | 2015/16, one match, giving a clean sheet rate of 1.00 |
| McNair | HUL | 2016/17 |
| Dowell, Drameh, Egan, Giles, McBurnie, Burstow, Woolfenden | HUL, COV | 2021/22 to 2024/25 |

Established squads are clean: fourteen players sampled across fourteen clubs all had a genuine 2025/26 record. This is a promoted-club problem specifically.

Also fixed while in there: a player FPL did not answer for was being receipted as having no past, writing him off for the season on a timeout.

## 3. The promoted assumption does not generalise, and needed evidence behind it

The rule merged in #112 says an unknown club concedes like the worst in the league. Correct for goals. **Wrong for defending**, and the data says so: Sunderland and Leeds came up a year ago and make 8.4 actions a game against a league middle of 8.2, while the busiest sides are Everton (10.2) and Newcastle (9.2), both long established. Copying the rule would have handed players nobody has seen the best defensive record in the game. So an unknown club is ordinary there and worst for conceding, each justified separately.

A club figure now also needs three players behind it. Ipswich had exactly one defender with a conceded rate and the whole squad was inheriting it.

## Effect, real GW1 data

| position | ranked | move 5+ places | top ten |
|---|---|---|---|
| defender | 184 | 77 | same players, one swap |
| midfielder | 245 | 21 | Rice into the top four |
| forward | 68 | 12 | unchanged |

The middle of the defender table reshuffles hard, which is what adding a whole scoring category should do: it does not change who the best attacking defenders are, it changes who the best cheap defensive picks are.

## Worth knowing

- **Grades inflate for defenders and midfielders.** Maguire B+ to A, four defenders up a band in the top ten. The bands were calibrated against a model missing 0.3 to 1.3 points a game for these positions, so they deserve a re-read once this settles.
- **The threshold model is a placeholder.** Real counts are more spread out than assumed, so this understates players just below the bar and overstates those just above. `SyncPerformances` already stores per-match `defensive_contribution`, so a few gameweeks in we can measure the share of matches a player actually clears it and drop the assumption entirely.
- **`RECORD_VERSION` goes to 4.0**, so every player is re-asked. Roughly two hourly runs.
- The stale-season fix largely empties the population the promoted fallback was built for, since an accepted 2025/26 season carries the conceded and defending rates with it. The fallback stays as the safety net it was meant to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138XYZYshV5yABvnj7R5p2x