### PR TITLE
Give the icons a version, because Cloudflare is holding the bolt until 2027

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
   end
 
   def meta_image
-    content_for?(:meta_image) ? content_for(:meta_image) : "#{BASE_URL}/icon.png"
+    content_for?(:meta_image) ? content_for(:meta_image) : "#{BASE_URL}/icon.png?v=#{FantasyForecast::ICON_VERSION}"
   end
 
   def meta_url
@@ -65,7 +65,7 @@ module ApplicationHelper
 
   def organization_schema
     { "@type": "Organization", "@id": "#{BASE_URL}/#organization", "name": "Fantasy Forecast",
-      "url": "#{BASE_URL}/", "logo": { "@type": "ImageObject", "url": "#{BASE_URL}/icon.png" }, "sameAs": [] }
+      "url": "#{BASE_URL}/", "logo": { "@type": "ImageObject", "url": "#{BASE_URL}/icon.png?v=#{FantasyForecast::ICON_VERSION}" }, "sameAs": [] }
   end
 
   def player_schema(player)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,11 +47,15 @@
         browser fakes the weight and the logo's measured spacing stops being true. %>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <link rel="icon" href="/favicon.ico" type="image/x-icon">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="apple-touch-icon" href="/icon.png">
-    <link rel="shortcut icon" href="/favicon.ico">
+    <%# Propshaft fingerprints what it compiles, but these live in public/ and are served
+        with a year of max-age, so Cloudflare and every browser that has ever seen the old
+        bolt will hold it until 2027. The version is the only thing that makes the URL new.
+        Bump it whenever the icons change. %>
+    <link rel="icon" href="/favicon.ico?v=<%= FantasyForecast::ICON_VERSION %>" type="image/x-icon">
+    <link rel="icon" href="/icon.svg?v=<%= FantasyForecast::ICON_VERSION %>" type="image/svg+xml">
+    <link rel="icon" href="/icon.png?v=<%= FantasyForecast::ICON_VERSION %>" type="image/png">
+    <link rel="apple-touch-icon" href="/icon.png?v=<%= FantasyForecast::ICON_VERSION %>">
+    <link rel="shortcut icon" href="/favicon.ico?v=<%= FantasyForecast::ICON_VERSION %>">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>

--- a/config/initializers/fantasy_forecast.rb
+++ b/config/initializers/fantasy_forecast.rb
@@ -1,4 +1,9 @@
 module FantasyForecast
+  # The favicons live in public/, which Rails serves with a year of max-age and no
+  # fingerprint, so Cloudflare and every browser that has seen an old one will hold it
+  # until 2027. Bumping this is what makes the URL new. Change it whenever the icons do.
+  ICON_VERSION = 2
+
   # Configuration for position-based forecasting
   # The game: Beat the Bot - try to be more accurate than FantasyForecaster
   POSITION_CONFIG = {


### PR DESCRIPTION
Production shipped the new mark and nobody could see it. Cloudflare was serving the lightning bolt from a copy seven and a half days old:

```
cf-cache-status: HIT
age: 648401
cache-control: public, max-age=31556952
```

Propshaft fingerprints what it compiles, so a stylesheet gets a new URL and a new URL is always fetched. The favicons live in `public/`, which Rails serves with a year of max-age and no fingerprint, so the URL never changes and neither does what anyone sees. Incognito did not help, because incognito still asks Cloudflare.

A version query is the only thing that makes those URLs new. It covers both places the old icon was still handed out: the link tags, and the Open Graph and structured data image, which social platforms cache harder than any browser.

This does not clear what Cloudflare already holds under the old URLs. Those entries simply stop being asked for.

238 tests pass, RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFta6GDgeuJYAiXzYYRLCS