### PR TITLE
Read a forecast at three distances, and stop asking whether it is the season

### DIFF
--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -37,7 +37,7 @@ class ComparisonsController < ApplicationController
   private
 
   def horizon
-    params[:horizon] == SEASON ? SEASON : "gameweek"
+    Horizon.find(params[:horizon]).key
   end
 
   def load_head_to_head

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -77,7 +77,7 @@ class PlayersController < ApplicationController
 
   def load_player
     @next_gameweek = Gameweek.next_gameweek
-    @horizon = params[:horizon] == SEASON ? SEASON : "gameweek"
+    @horizon = Horizon.find(params[:horizon]).key
     @card_path = player_path(@player, format: :png)
     load_player_forecast
   end
@@ -131,7 +131,7 @@ class PlayersController < ApplicationController
   end
 
   def season_divisor
-    @horizon == SEASON ? Gameweek.remaining_count : 1
+    Horizon.find(@horizon).divisor
   end
 
   def load_player_performances
@@ -219,11 +219,11 @@ class PlayersController < ApplicationController
 
   # Where a horizon lives. The season has a page of its own; a week is named by
   # its number.
-  def position_rankings_path(horizon, position, **extra)
-    if horizon == SEASON
-      season_position_path(position: "#{position}s", **extra)
-    else
-      gameweek_position_path(gameweek: horizon, position: "#{position}s", **extra)
+  def position_rankings_path(segment, position, **extra)
+    case segment.to_s
+    when Horizon::SEASON then season_position_path(position: "#{position}s", **extra)
+    when Horizon::UPCOMING then upcoming_position_path(position: "#{position}s", **extra)
+    else gameweek_position_path(gameweek: segment, position: "#{position}s", **extra)
     end
   end
 
@@ -241,26 +241,26 @@ class PlayersController < ApplicationController
     (value.to_f * TENTHS_PER_MILLION).round
   end
 
-  # The season horizon is anchored to the next gameweek: its rows are stored
-  # against that week, and validation and titling resolve a real gameweek from it.
+  # Every horizon but the coming week is anchored to the next gameweek: their rows
+  # are stored against it, and validation and titling resolve a real gameweek from it.
   def set_horizon
-    if season_requested?
-      @horizon = SEASON
-      @gameweek = next_gameweek&.fpl_id
-    else
-      @horizon = "gameweek"
-      @gameweek = params[:gameweek].present? ? params[:gameweek].to_i : current_gameweek
-    end
+    @horizon = horizon.key
+    @gameweek = horizon.gameweek? ? requested_gameweek : next_gameweek&.fpl_id
   end
 
-  # The season page says so in its route; the horizon dropdown says so in the
-  # parameter it submits, on its way to that page.
-  def season_requested?
-    params[:horizon] == SEASON || params[:gameweek] == SEASON
+  # A route says which horizon it is in the parameter it defaults; the toggle says it
+  # in the one it submits. Anything else is a gameweek number, or a stranger's guess
+  # at a horizon, and both resolve to the coming week.
+  def horizon
+    @horizon_read ||= Horizon.find(params[:horizon].presence || params[:gameweek])
+  end
+
+  def requested_gameweek
+    params[:gameweek].present? ? params[:gameweek].to_i : current_gameweek
   end
 
   def season?
-    @horizon == SEASON
+    horizon.season?
   end
 
   def resolve_position(param)
@@ -285,7 +285,7 @@ class PlayersController < ApplicationController
   # A season total is read as its per-gameweek average, so it meets the same tier
   # bands a single week does.
   def tier_divisor
-    season? ? Gameweek.remaining_count : 1
+    horizon.divisor
   end
 
   # When the numbers on the page were worked out. They are rewritten on the hour
@@ -406,14 +406,17 @@ class PlayersController < ApplicationController
     options
   end
 
+  # What this horizon is called in an address: a gameweek by its number, the rest by
+  # their own name.
   def horizon_param
-    season? ? SEASON : @gameweek
+    horizon.gameweek? ? @gameweek : horizon.key
   end
 
   # This same page read at the other horizon. Changing horizon is not a reason to
   # forget the team and the prices you already chose, so those travel with it.
   def horizon_url(which)
-    position_rankings_path(which == :season ? SEASON : @gameweek, @position_filter, **retained_filters)
+    segment = which.to_s == Horizon::GAMEWEEK ? @gameweek : which.to_s
+    position_rankings_path(segment, @position_filter, **retained_filters)
   end
 
   def retained_filters
@@ -438,11 +441,14 @@ class PlayersController < ApplicationController
   end
 
   def horizon_label
-    season? ? "Rest of Season" : "Gameweek #{@gameweek}"
+    horizon.label(gameweek: @gameweek)
   end
 
+  # A title tag wants the week as GW1 and the others in full: there is room for "Rest
+  # of Season" in a title and none for it in a toggle, which is why the short name the
+  # control uses is not the short name a title wants.
   def horizon_short
-    season? ? "Rest of Season" : "GW#{@gameweek}"
+    horizon.gameweek? ? horizon.short_label(gameweek: @gameweek) : horizon.label
   end
 
   # The heading and the title tag say the same thing, in the words somebody would

--- a/app/controllers/squads_controller.rb
+++ b/app/controllers/squads_controller.rb
@@ -39,15 +39,21 @@ class SquadsController < ApplicationController
     [ "squad_card", @horizon, @gameweek&.id, @squad.updated_at.to_i ].join("/")
   end
 
-  def season? = @horizon == SEASON
+  def horizon = @horizon_read ||= Horizon.find(@horizon)
+
+  def season? = horizon.season?
   helper_method :season?
 
-  def horizon_label = season? ? "Rest of Season" : "Gameweek #{@gameweek&.fpl_id}"
+  def horizon_label = horizon.label(gameweek: @gameweek&.fpl_id)
   helper_method :horizon_label
 
   # The address this squad is at, and the address its card is at.
-  def squad_url(format: nil)
-    season? ? season_squad_path(format: format) : squad_path(format: format)
+  def squad_url(format: nil, reach: horizon)
+    case reach.to_s
+    when Horizon::SEASON then season_squad_path(format: format)
+    when Horizon::UPCOMING then upcoming_squad_path(format: format)
+    else squad_path(format: format)
+    end
   end
   helper_method :squad_url
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,16 +39,24 @@ module ApplicationHelper
   #
   # Links rather than a form, so both horizons are addresses a crawler can follow and
   # the toggle needs no JavaScript to work.
-  def forecast_horizons(gameweek:, season:, gameweek_url:, season_url:)
-    [
+  # A page offers a horizon only if it has an address for it. The comparison and the
+  # squad are worked out for a week and for a season and not for the run between, so
+  # they hand over two addresses and get two choices; the rankings hand over three.
+  #
+  # Both names come from the Horizon itself rather than being written here, so the
+  # middle one cannot come to disagree with the football it actually covers.
+  def forecast_horizons(current:, urls:, gameweek: nil)
+    Horizon.all.filter_map do |horizon|
+      url = urls[horizon.key.to_sym]
+      next if url.blank?
+
       PageHeadingComponent::Horizon.new(
-        label: gameweek ? "Gameweek #{gameweek}" : "Next Gameweek",
-        url: gameweek_url, current: !season
-      ),
-      PageHeadingComponent::Horizon.new(
-        label: "Rest of Season", url: season_url, current: season
+        label: horizon.label(gameweek: gameweek),
+        short_label: horizon.short_label(gameweek: gameweek),
+        url: url,
+        current: horizon.key == current.to_s
       )
-    ]
+    end
   end
 
   def meta_title

--- a/app/helpers/cards_helper.rb
+++ b/app/helpers/cards_helper.rb
@@ -65,11 +65,15 @@ module CardsHelper
     team&.color || Team::DEFAULT_COLOR
   end
 
-  # A score as the week it describes, which is the scale the grades are read on.
-  # A season total shown raw would be forty points beside somebody else's four.
-  def card_points(score, season)
+  # A score as the week it describes, which is the scale the grades are read on. A
+  # total shown raw would be forty points beside somebody else's four.
+  #
+  # Given the horizon rather than told whether it is the season, because "not the
+  # season" stopped meaning "one week" the moment there were three of them: a
+  # five-gameweek total divided by one was printed as though it were a single week's.
+  def card_points(score, horizon)
     return "—" if score.nil?
 
-    format("%.1f", score / (season ? Gameweek.remaining_count : 1))
+    format("%.1f", score / Horizon.find(horizon).divisor)
   end
 end

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -38,7 +38,7 @@ module ComparisonsHelper
   def weekly_points(head_to_head, side)
     return unless side.forecast?
 
-    format("%.1f", side.score / (head_to_head.season? ? Gameweek.remaining_count : 1))
+    format("%.1f", side.score / Horizon.find(head_to_head.horizon).divisor)
   end
 
   # A side of a comparison in the terms the compact card asks for, so the pair are
@@ -79,7 +79,7 @@ module ComparisonsHelper
   end
 
   def horizon_line(head_to_head)
-    head_to_head.season? ? "Expected points for the rest of the season." : "Expected points this gameweek."
+    "Expected points for #{Horizon.find(head_to_head.horizon).span}."
   end
 
   # A player we cannot forecast is not a player we rate at nought, and the page

--- a/app/models/horizon.rb
+++ b/app/models/horizon.rb
@@ -1,0 +1,114 @@
+# How far ahead a forecast is read.
+#
+# There were two of these and they were asked about as a yes or no: everything on the
+# site wanted to know whether it was looking at the season, and answered every other
+# question from that. A third distance makes that shape wrong, because "not the
+# season" stops meaning "this week".
+#
+# So a horizon is a thing rather than a flag. It knows the run of gameweeks it spans,
+# which is the only question the forecaster, the grader and the pages all actually
+# ask, in three different accents:
+#
+#   the forecaster  which fixtures am I reading?
+#   the grader      how many weeks is this score spread over?
+#   the pages       what do I call it, and what does it cost to say?
+class Horizon
+  # How far the middle horizon looks. Every label is written from this number rather
+  # than repeating it, so moving to four or six weeks renames nothing and redirects
+  # nothing: the stored key and the address do not carry it.
+  WINDOW = 5
+
+  GAMEWEEK = "gameweek".freeze
+  UPCOMING = "upcoming".freeze
+  SEASON = "season".freeze
+
+  KEYS = [ GAMEWEEK, UPCOMING, SEASON ].freeze
+
+  attr_reader :key
+
+  def self.all = KEYS.map { |key| new(key) }
+
+  # Anything unrecognised is the coming week. A horizon arrives from a URL, and a
+  # stranger's guess at one should be answered rather than refused.
+  def self.find(key) = new(KEYS.include?(key.to_s) ? key.to_s : GAMEWEEK)
+
+  def self.default = new(GAMEWEEK)
+
+  def initialize(key)
+    @key = key
+  end
+
+  def gameweek? = key == GAMEWEEK
+  def upcoming? = key == UPCOMING
+  def season? = key == SEASON
+
+  # The run of gameweeks this reads over, always starting at the next one.
+  def gameweeks
+    case key
+    when GAMEWEEK then Gameweek.remaining.limit(1)
+    when UPCOMING then Gameweek.remaining.limit(WINDOW)
+    else Gameweek.remaining
+    end
+  end
+
+  # What a score over this horizon is divided by to read as a single week, so a grade
+  # means the same thing whichever distance it was worked out over.
+  #
+  # Counted rather than assumed: near the end of a season "the next five" is however
+  # many are left, and a horizon with no football in it still has to be safe to
+  # divide by.
+  def divisor = [ gameweeks.count, 1 ].max
+
+  # What it is called, and what it is called when there is no room for that.
+  #
+  # Written from WINDOW rather than repeating the number, so the label cannot come to
+  # disagree with the football it covers. Three options do not fit a phone at full
+  # length, which is what the short one is for: the control shows it below sm and
+  # keeps the full name as the accessible one either way.
+  def label(gameweek: nil)
+    case key
+    when GAMEWEEK then gameweek ? "Gameweek #{gameweek}" : "Next Gameweek"
+    when UPCOMING then "Next #{WINDOW} Gameweeks"
+    else "Rest of Season"
+    end
+  end
+
+  def short_label(gameweek: nil)
+    case key
+    when GAMEWEEK then gameweek ? "GW#{gameweek}" : "Next GW"
+    when UPCOMING then "Next #{WINDOW}"
+    else "Season"
+    end
+  end
+
+  # The distance said as a phrase, for the sentences that have to name it: "expected
+  # points for the next five gameweeks". Written here so a page cannot label a number
+  # with a stretch of football it was not worked out over, which is exactly what
+  # happened when this was a yes-or-no: anything that was not the season was called
+  # "this gameweek", and a five-week total was printed under it.
+  def span
+    case key
+    when GAMEWEEK then "this gameweek"
+    when UPCOMING then "the next #{WINDOW} gameweeks"
+    else "the rest of the season"
+    end
+  end
+
+  # The same thing where there is no room for it, as on a card.
+  def short_span
+    case key
+    when GAMEWEEK then "this week"
+    when UPCOMING then "next #{WINDOW}"
+    else "rest of season"
+    end
+  end
+
+  # Whether a score over this distance is a total that has to be read back to a week
+  # before it can be graded or compared.
+  def total? = divisor > 1
+
+  def ==(other) = other.is_a?(Horizon) && other.key == key
+  alias eql? ==
+  def hash = key.hash
+  def to_s = key
+end

--- a/app/models/squad.rb
+++ b/app/models/squad.rb
@@ -6,7 +6,7 @@
 class Squad < ApplicationRecord
   belongs_to :gameweek
 
-  HORIZONS = %w[gameweek season].freeze
+  HORIZONS = Horizon::KEYS
   SEASON = "season".freeze
   GOALKEEPER = "goalkeeper".freeze
 
@@ -52,9 +52,13 @@ class Squad < ApplicationRecord
   def spent_on_starters = starters.sum { |pick| pick["cost"].to_i }
   def banked = SquadOptimiser::BUDGET - cost
 
-  def season? = horizon == SEASON
+  def season? = reach.season?
+
+  # The distance this squad was picked over, which knows both how far it looks and
+  # what to divide its score by to read as a single week.
+  def reach = Horizon.find(horizon)
 
   private
 
-  def points_divisor = season? ? Gameweek.remaining_count : 1
+  def points_divisor = reach.divisor
 end

--- a/app/services/fpl/hourly_pipeline.rb
+++ b/app/services/fpl/hourly_pipeline.rb
@@ -55,7 +55,9 @@ module Fpl
       gameweek = Gameweek.next_gameweek
       return nothing_to_forecast unless gameweek
 
-      forecast = [ WeeklyForecast.call(gameweek: gameweek), SeasonForecast.call(gameweek: gameweek) ].all?
+      forecast = [ WeeklyForecast.call(gameweek: gameweek),
+                   UpcomingForecast.call(gameweek: gameweek),
+                   SeasonForecast.call(gameweek: gameweek) ].all?
       optimise_squads(gameweek)
       forecast
     end

--- a/app/services/head_to_head.rb
+++ b/app/services/head_to_head.rb
@@ -158,13 +158,13 @@ class HeadToHead < ApplicationService
       tier: TierCalculator.tier_from_points(weekly(score)) }
   end
 
-  # A rest-of-season score is dozens of points where a week's is two to four, so
-  # it is read as the week it averages to before it is graded or compared. Both
-  # horizons then answer on the same scale.
+  # A rest-of-season score is dozens of points where a week's is two to four, so it is
+  # read as the week it averages to before it is graded or compared. Every horizon then
+  # answers on the same scale, whichever distance it was worked out over.
   def weekly(score)
     return 0.0 if score.nil?
 
-    score / (season? ? Gameweek.remaining_count : 1)
+    score / Horizon.find(@horizon).divisor
   end
 
   def forecasts

--- a/app/services/upcoming_forecast.rb
+++ b/app/services/upcoming_forecast.rb
@@ -1,0 +1,48 @@
+# What every player is expected to score over the next few gameweeks, stored against
+# the coming one as its anchor. See Forecaster for the how and the why.
+#
+# This is the horizon a transfer is actually made over. The weekly forecast answers
+# who to captain and the season one answers who to hold, but neither answers the
+# question a manager spends his transfers on: who is worth owning for the run of
+# fixtures in front of him.
+#
+# It is also the horizon this model is least naive about. A season total applies
+# today's form, price and availability the whole way to May, which the season
+# forecast admits is "progressively less honest the further ahead you read". Over
+# five weeks that snapshot is still broadly true, so the same arithmetic is doing far
+# less pretending here than it does there.
+class UpcomingForecast < Forecaster
+  # Both of these sit between the two horizons either side of it, because that is
+  # honestly where five weeks sits.
+  #
+  # The band a record may pull a player off his price is drawn a little tighter than
+  # the coming week's 0.05 and wider than the season's 0.03. A returning star earns
+  # his price back over a season and not over one weekend; over five weeks he is
+  # partway there.
+  CLAMP_WIDTH = 0.04
+
+  # A new signing's record is capped at half a match in the coming week and let up to
+  # three quarters over a season, by when he will long since have settled. Five weeks
+  # is most of a settling-in period, so it lands between.
+  NEW_CLUB_MINUTES = 0.6
+
+  private
+
+  def horizon
+    Horizon::UPCOMING
+  end
+
+  def matches
+    Match.includes(:home_team, :away_team).where(gameweek: window)
+  end
+
+  # The horizon itself, asked for once: both the fixtures it spans and the fitness it
+  # is read over are the same run of gameweeks.
+  def window
+    @window ||= Horizon.new(Horizon::UPCOMING).gameweeks.to_a
+  end
+
+  def model_overrides
+    { clamp_width: CLAMP_WIDTH, new_club_minutes: NEW_CLUB_MINUTES }
+  end
+end

--- a/app/views/cards/comparison.svg.erb
+++ b/app/views/cards/comparison.svg.erb
@@ -43,7 +43,7 @@
   </g>
 
   <%= render "cards/header", title: comparison_question(@comparison),
-             note: @head_to_head.season? ? "Rest of season" : "Gameweek #{@gameweek&.fpl_id}" %>
+             note: Horizon.find(@head_to_head.horizon).label(gameweek: @gameweek&.fpl_id) %>
 
   <%# The answer, which is the whole reason the card exists. %>
   <%# A name now, always, so the card that lands in a chat answers the question it

--- a/app/views/cards/player.svg.erb
+++ b/app/views/cards/player.svg.erb
@@ -4,7 +4,7 @@
 %>
 <% team = @player.team %>
 <% ink = card_ink(team) %>
-<% season = @horizon == "season" %>
+<% reach = Horizon.find(@horizon) %>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      width="<%= ShareCard::WIDTH %>" height="<%= ShareCard::HEIGHT %>"
      viewBox="0 0 <%= ShareCard::WIDTH %> <%= ShareCard::HEIGHT %>"
@@ -12,7 +12,7 @@
   <rect width="1200" height="630" fill="#09090b"/>
 
   <%= render "cards/header", title: @player.full_name,
-             note: season ? "Rest of season" : "Gameweek #{@next_gameweek&.fpl_id}" %>
+             note: reach.label(gameweek: @next_gameweek&.fpl_id) %>
 
   <%# His shirt, cut on the same diagonal the rankings rows use. %>
   <clipPath id="board"><rect x="0" y="88" width="1200" height="404"/></clipPath>
@@ -31,7 +31,7 @@
     </text>
 
     <% [ [ "Grade", @forecast&.dig(:grade) || "—", 56 ],
-         [ season ? "XP rest of season" : "XP this week", card_points(@forecast&.dig(:score), season), 300 ],
+         [ "XP #{reach.short_span}", card_points(@forecast&.dig(:score), @horizon), 300 ],
          [ "Rank", @forecast&.dig(:rank) ? "##{@forecast[:rank]}" : "—", 560 ] ].each do |label, value, x| %>
       <text x="<%= x %>" y="360" fill="<%= ink %>" font-size="15" font-weight="700"
             letter-spacing="1.5" opacity="0.7"><%= label.upcase %></text>

--- a/app/views/cards/rankings.svg.erb
+++ b/app/views/cards/rankings.svg.erb
@@ -25,7 +25,7 @@
       <%= player.team&.short_name %>
     </text>
     <text x="1010" y="<%= y %>" text-anchor="end" fill="#a1a1aa" font-size="26" font-weight="700">
-      <%= card_points(ranking.score, season?) %>
+      <%= card_points(ranking.score, @horizon) %>
     </text>
     <text x="1144" y="<%= y %>" text-anchor="end" fill="#fafafa" font-size="34" font-weight="800">
       <%= ranking.grade %>
@@ -34,7 +34,7 @@
 
   <% if best && (player = @players_by_id[best.player_id]) %>
     <%= render "cards/footer", label: "Our top pick", size: 44,
-               headline: "#{player.display_name.upcase} · #{card_points(best.score, season?)} XP" %>
+               headline: "#{player.display_name.upcase} · #{card_points(best.score, @horizon)} XP" %>
   <% else %>
     <%= render "cards/footer", label: "Fantasy Forecast", size: 40,
                headline: "EVERY PLAYER GRADED A TO F" %>

--- a/app/views/comparisons/show.html.erb
+++ b/app/views/comparisons/show.html.erb
@@ -1,4 +1,5 @@
-<% horizon_words = @head_to_head.season? ? "Rest of Season" : "Gameweek #{@gameweek&.fpl_id}" %>
+<% reach = Horizon.find(@head_to_head.horizon) %>
+<% horizon_words = reach.label(gameweek: @gameweek&.fpl_id) %>
 <% content_for :meta_title, "#{comparison_title(@comparison)} FPL #{horizon_words} | Fantasy Forecast" %>
 <% content_for :meta_description, "#{comparison_question(@comparison)} #{verdict_line(@head_to_head)} Both graded A to F from price, ownership, form and fixtures." %>
 <% content_for :meta_url, "#{ApplicationHelper::BASE_URL}#{comparison_path(pair: @comparison.slug)}" %>
@@ -10,9 +11,10 @@
       updated_at: @forecast_at,
       share: "Share this answer",
       back: back_to("Comparisons", comparisons_path),
-      horizons: forecast_horizons(gameweek: @gameweek&.fpl_id, season: @head_to_head.season?,
-                                  gameweek_url: comparison_path(pair: @comparison.slug),
-                                  season_url: comparison_path(pair: @comparison.slug, horizon: "season"))) %>
+      horizons: forecast_horizons(gameweek: @gameweek&.fpl_id, current: @horizon,
+                                  urls: { gameweek: comparison_path(pair: @comparison.slug),
+                                          upcoming: comparison_path(pair: @comparison.slug, horizon: "upcoming"),
+                                          season: comparison_path(pair: @comparison.slug, horizon: "season") })) %>
 
 <%# Two columns at every width, phone included. A comparison with one player above
     the other is a list, and you cannot read a list across. %>
@@ -81,8 +83,8 @@
   <p class="mt-2 text-sm text-zinc-600">
     Both players are forecast the same way: their price and how many managers own them lead, weighed
     against minutes, recent form, expected goals and assists, and who they are playing.
-    <%= @head_to_head.season? ?
-        "Rest-of-season scores are totals, so they are read as the week they average to before they are graded." :
+    <%= reach.total? ?
+        "Scores over more than one gameweek are totals, so they are read as the week they average to before they are graded." :
         "The score is the points we expect from the coming gameweek alone." %>
     <% if @head_to_head.close? %>
       The gap here is under <%= HeadToHead::CLOSE %> of a point a week, which is smaller than the

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -20,9 +20,10 @@
             updated_at: @forecast_at,
             share: "Share these rankings",
             back: back_home,
-            horizons: forecast_horizons(gameweek: @gameweek, season: season?,
-                                        gameweek_url: horizon_url(:gameweek),
-                                        season_url: horizon_url(:season))) %>
+            horizons: forecast_horizons(gameweek: @gameweek, current: @horizon,
+                                        urls: { gameweek: horizon_url(:gameweek),
+                                                upcoming: horizon_url(:upcoming),
+                                                season: horizon_url(:season) })) %>
     </div>
 
     <%# Each filter on its own line on a phone, one row from sm up: position first,

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -13,9 +13,10 @@
       updated_at: @forecast_at,
       share: "Share #{@player.display_name}'s forecast",
       back: back_to("Rankings", rankings_path(position: @player.position)),
-      horizons: (forecast_horizons(gameweek: @next_gameweek&.fpl_id, season: @horizon == "season",
-                                   gameweek_url: player_path(@player),
-                                   season_url: player_path(@player, horizon: "season")) if @forecast)) %>
+      horizons: (forecast_horizons(gameweek: @next_gameweek&.fpl_id, current: @horizon,
+                                   urls: { gameweek: player_path(@player),
+                                           upcoming: player_path(@player, horizon: "upcoming"),
+                                           season: player_path(@player, horizon: "season") }) if @forecast)) %>
 
 <!-- Player Banner -->
 <div class="mt-6">
@@ -48,7 +49,7 @@
 <%# The horizon toggle now lives in the heading, so the whole page navigates rather
     than the panel alone. Turbo Drive still swaps the body without a reload. %>
 <% if @forecast %>
-  <% season = @forecast[:horizon] == "season" %>
+  <% reach = Horizon.find(@forecast[:horizon]) %>
   <div class="mt-4 rounded-xl bg-zinc-100 p-5 sm:p-7">
     <dl class="flex flex-wrap items-baseline gap-x-6 gap-y-4 lg:gap-x-10">
       <% if @forecast[:rank] %>
@@ -65,7 +66,7 @@
       <% end %>
       <% if @forecast[:score] %>
         <div>
-          <dt class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Expected points <%= season ? "rest of season" : "this gameweek" %></dt>
+          <dt class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Expected points for <%= reach.span %></dt>
           <dd class="mt-1.5 text-3xl font-extrabold leading-none tracking-[-0.03em] tabular-nums text-zinc-950"><%= format("%.1f", @forecast[:score]) %></dd>
         </div>
       <% end %>

--- a/app/views/shared/sitemap.xml.erb
+++ b/app/views/shared/sitemap.xml.erb
@@ -21,9 +21,14 @@
     <priority>0.9</priority>
   </url>
 
-  <!-- The best fifteen the budget buys, both horizons -->
+  <!-- The best fifteen the budget buys, at each distance it is picked over -->
   <url>
     <loc><%= @base_url %><%= squad_path %></loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc><%= @base_url %><%= upcoming_squad_path %></loc>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
@@ -33,8 +38,15 @@
     <priority>0.8</priority>
   </url>
 
-  <!-- Season Rankings Pages: the one ranking URL that is good all year -->
+  <!-- The two ranking URLs that are good all year: the run of fixtures ahead, and
+       the whole of what is left. A gameweek's own page goes stale the week it is
+       played; these two never do. -->
   <% %w[forwards midfielders defenders goalkeepers].each do |position| %>
+  <url>
+    <loc><%= @base_url %><%= upcoming_position_path(position: position) %></loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
   <url>
     <loc><%= @base_url %><%= season_position_path(position: position) %></loc>
     <changefreq>daily</changefreq>

--- a/app/views/squads/show.html.erb
+++ b/app/views/squads/show.html.erb
@@ -12,8 +12,9 @@
         updated_at: @forecast_at,
         share: ("Share this squad" if @squad),
         back: back_home,
-        horizons: forecast_horizons(gameweek: @gameweek&.fpl_id, season: season?,
-                                    gameweek_url: squad_path, season_url: season_squad_path)) %>
+        horizons: forecast_horizons(gameweek: @gameweek&.fpl_id, current: @horizon,
+                                    urls: { gameweek: squad_path, upcoming: upcoming_squad_path,
+                                            season: season_squad_path })) %>
 </div>
 
 <% if @squad %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,12 @@ Rails.application.routes.draw do
   get "gameweeks/:gameweek/:position", to: "players#index", as: :gameweek_position,
       constraints: { gameweek: /\d+/, position: POSITIONS }
 
+  # The run of fixtures a transfer is actually made over. No number in the address:
+  # how far it looks is Horizon::WINDOW's business, and moving it should not move the
+  # page.
+  get "upcoming/:position", to: "players#index", as: :upcoming_position,
+      defaults: { horizon: "upcoming" }, constraints: { position: POSITIONS }
+
   # The season used to be spelled as though it were a gameweek.
   get "gameweeks/ros/:position", to: redirect("/season/%{position}", status: 301),
       constraints: { position: POSITIONS }
@@ -53,6 +59,7 @@ Rails.application.routes.draw do
   # spend something we were not advising them to spend, and it was called the best XI,
   # which is not what fifteen players are.
   get "squad", to: "squads#show", as: :squad, defaults: { horizon: "gameweek" }
+  get "squad/upcoming", to: "squads#show", as: :upcoming_squad, defaults: { horizon: "upcoming" }
   get "squad/season", to: "squads#show", as: :season_squad, defaults: { horizon: "season" }
 
   # Dynamic robots.txt based on environment

--- a/test/controllers/comparisons_controller_test.rb
+++ b/test/controllers/comparisons_controller_test.rb
@@ -82,7 +82,7 @@ class ComparisonsControllerTest < ActionDispatch::IntegrationTest
     get comparison_path(pair: pair, horizon: "season")
 
     assert_response :success
-    assert_select "[aria-label='Forecast horizon'] a[aria-current=page]", text: "Rest of Season"
+    assert_select "[aria-label='Forecast horizon'] a[aria-current=page][aria-label='Rest of Season']"
     assert_select "[data-comparison-card][data-pick=true]", text: /Palmer/
   end
 

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -201,10 +201,12 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
 
     # Still defaults to the latest gameweek that has forecasts (5) for display
     assert_includes response.body, "Gameweek 5"
-    # The horizon toggle offers two horizons, never a list of every week played
-    assert_select "[aria-label='Forecast horizon'] a", text: "Rest of Season"
-    assert_select "[aria-label='Forecast horizon'] a", text: "Gameweek 1", count: 0
-    assert_select "[aria-label='Forecast horizon'] a", count: 2
+    # The toggle offers the three distances a forecast is read at, never a list of
+    # every week played. Matched on the accessible name: each option carries a short
+    # name and a full one, and the visible text is whichever the breakpoint picks.
+    assert_select "[aria-label='Forecast horizon'] a[aria-label='Rest of Season']"
+    assert_select "[aria-label='Forecast horizon'] a[aria-label='Gameweek 1']", count: 0
+    assert_select "[aria-label='Forecast horizon'] a", count: 3
   end
 
   test "the season route shows season forecasts" do
@@ -214,7 +216,7 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, @player.short_name
     assert_includes response.body, "Rest of Season"
-    assert_select "[aria-label='Forecast horizon'] a[aria-current=page]", text: "Rest of Season"
+    assert_select "[aria-label='Forecast horizon'] a[aria-current=page][aria-label='Rest of Season']"
   end
 
   test "the season page the horizon dropdown asks for is the season page" do
@@ -241,9 +243,10 @@ class PlayersControllerTest < ActionDispatch::IntegrationTest
   test "the horizon toggle names the gameweek and the season, as links" do
     get rankings_path
 
-    assert_select "[aria-label='Forecast horizon'] a", text: "Gameweek 2"
-    assert_select "[aria-label='Forecast horizon'] a", text: "Rest of Season"
-    assert_select "[aria-label='Forecast horizon'] a[aria-current=page]", text: "Gameweek 2"
+    assert_select "[aria-label='Forecast horizon'] a[aria-label='Gameweek 2']"
+    assert_select "[aria-label='Forecast horizon'] a[aria-label='Next 5 Gameweeks']"
+    assert_select "[aria-label='Forecast horizon'] a[aria-label='Rest of Season']"
+    assert_select "[aria-label='Forecast horizon'] a[aria-current=page][aria-label='Gameweek 2']"
   end
 
   # The positions are the same control as the horizon, and links for the same

--- a/test/models/horizon_test.rb
+++ b/test/models/horizon_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+# The three distances a forecast is read at. This was a yes-or-no until there were
+# three of them, and the questions below are the ones everything else asks it: how far
+# does this look, what do I divide by, and what do I call it.
+class HorizonTest < ActiveSupport::TestCase
+  setup do
+    Gameweek.destroy_all
+    @weeks = (1..10).map do |n|
+      Gameweek.create!(fpl_id: n, name: "Gameweek #{n}", start_time: n.days.from_now, is_next: n == 1)
+    end
+  end
+
+  test "each horizon looks over its own run of gameweeks, all starting at the next one" do
+    assert_equal [ 1 ], Horizon.new("gameweek").gameweeks.pluck(:fpl_id)
+    assert_equal (1..Horizon::WINDOW).to_a, Horizon.new("upcoming").gameweeks.pluck(:fpl_id)
+    assert_equal (1..10).to_a, Horizon.new("season").gameweeks.pluck(:fpl_id)
+  end
+
+  # A score is divided by this to read as a single week, so a grade means the same
+  # thing whichever distance it was worked out over.
+  test "what it divides by is the football it actually covers, counted not assumed" do
+    assert_equal 1, Horizon.new("gameweek").divisor
+    assert_equal Horizon::WINDOW, Horizon.new("upcoming").divisor
+    assert_equal 10, Horizon.new("season").divisor
+  end
+
+  # Near the end of a season "the next five" is however many are left, and a horizon
+  # with no football in it still has to be safe to divide by.
+  test "it never divides by nought, however little season is left" do
+    Gameweek.where.not(fpl_id: 1).destroy_all
+
+    assert_equal 1, Horizon.new("upcoming").divisor
+    assert_equal 1, Horizon.new("season").divisor
+
+    Gameweek.destroy_all
+    assert_equal 1, Horizon.new("season").divisor
+  end
+
+  test "a horizon nobody recognises is the coming week rather than an error" do
+    assert_predicate Horizon.find("nonsense"), :gameweek?
+    assert_predicate Horizon.find(nil), :gameweek?
+    assert_predicate Horizon.find("5"), :gameweek?
+    assert_predicate Horizon.find("upcoming"), :upcoming?
+  end
+
+  # The number is written from WINDOW in every place it appears, so moving the window
+  # cannot leave a label claiming a stretch of football it no longer covers.
+  test "every name carrying the window is written from it" do
+    upcoming = Horizon.new("upcoming")
+
+    [ upcoming.label, upcoming.short_label, upcoming.span, upcoming.short_span ].each do |name|
+      assert_includes name, Horizon::WINDOW.to_s, "#{name.inspect} does not carry the window"
+    end
+  end
+
+  test "the coming week is named by its number when there is one" do
+    assert_equal "Gameweek 7", Horizon.new("gameweek").label(gameweek: 7)
+    assert_equal "GW7", Horizon.new("gameweek").short_label(gameweek: 7)
+    assert_equal "Next Gameweek", Horizon.new("gameweek").label
+  end
+
+  # Anything spanning more than a week is a total, and a page has to say so before it
+  # puts the number next to a grade calibrated for one.
+  test "it knows whether its score is a total" do
+    assert_not_predicate Horizon.new("gameweek"), :total?
+    assert_predicate Horizon.new("upcoming"), :total?
+    assert_predicate Horizon.new("season"), :total?
+  end
+
+  test "two of the same horizon are the same horizon" do
+    assert_equal Horizon.new("season"), Horizon.find("season")
+    assert_not_equal Horizon.new("season"), Horizon.new("upcoming")
+    assert_equal 1, [ Horizon.new("season"), Horizon.find("season") ].uniq.size
+  end
+end

--- a/test/services/fpl/hourly_pipeline_test.rb
+++ b/test/services/fpl/hourly_pipeline_test.rb
@@ -98,8 +98,8 @@ class Fpl::HourlyPipelineTest < ActiveSupport::TestCase
     stored_squad(gameweek)
     Forecast.where(gameweek: gameweek).update_all(updated_at: 1.hour.ago)
 
-    assert_equal [ "season" ], horizons_searched(gameweek),
-                 "only the horizon without a current squad should be searched again"
+    assert_equal [ "upcoming", "season" ], horizons_searched(gameweek),
+                 "only the horizons without a current squad should be searched again"
   end
 
   test "searches again once a forecast is newer than the squad" do

--- a/test/services/upcoming_forecast_test.rb
+++ b/test/services/upcoming_forecast_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+# The horizon a transfer is actually made over. What matters here is that it reads the
+# run of fixtures in front of it and no further: a five-week forecast that quietly
+# spanned the season would be the season forecast under another name.
+class UpcomingForecastTest < ActiveSupport::TestCase
+  setup do
+    Forecast.destroy_all
+    Strategy.destroy_all
+    Gameweek.destroy_all
+    Match.destroy_all
+
+    @team = Team.create!(fpl_id: 810, name: "Test City", short_name: "TCY", code: 810)
+    @opponent = Team.create!(fpl_id: 811, name: "Test Rovers", short_name: "TRV", code: 811)
+
+    # Ten weeks of football, so the window has somewhere to stop short of.
+    @weeks = (1..10).map do |n|
+      week = Gameweek.create!(fpl_id: n, name: "Gameweek #{n}", start_time: n.days.from_now, is_next: n == 1)
+      Match.create!(gameweek: week, home_team: @team, away_team: @opponent,
+                    fpl_id: 8_200 + n, home_difficulty: 2, away_difficulty: 4)
+      week
+    end
+    @player = player_with_record
+  end
+
+  def player_with_record(fpl_id: 8300)
+    player = Player.create!(first_name: "Test", last_name: "Player#{fpl_id}", short_name: "T#{fpl_id}",
+                            fpl_id: fpl_id, code: fpl_id, team: @team, position: "forward")
+    {
+      "last_season_minutes" => 3000.0, "season_minutes" => 3000.0,
+      "last_season_expected_goals_per_90" => 0.5, "expected_goals_per_90" => 0.5,
+      "last_season_expected_goal_involvements_per_90" => 0.7,
+      "expected_goal_involvements_per_90" => 0.7, "selected_by_percent" => 10.0, "now_cost" => 80.0
+    }.each { |type, value| Statistic.create!(player: player, gameweek: @weeks.first, type: type, value: value) }
+    player
+  end
+
+  test "it stores against the coming gameweek, under its own horizon" do
+    UpcomingForecast.call(gameweek: @weeks.first)
+
+    forecast = Forecast.find_by(player: @player, horizon: "upcoming")
+    assert_not_nil forecast
+    assert_equal @weeks.first, forecast.gameweek
+  end
+
+  # The whole point of the horizon: it stops at the window, so it lands between the
+  # single week and the whole season rather than beside either.
+  test "it spans the window and no further" do
+    WeeklyForecast.call(gameweek: @weeks.first)
+    UpcomingForecast.call(gameweek: @weeks.first)
+    SeasonForecast.call(gameweek: @weeks.first)
+
+    scores = %w[gameweek upcoming season].index_with do |horizon|
+      Forecast.find_by(player: @player, horizon: horizon).score.to_f
+    end
+
+    assert_operator scores["upcoming"], :>, scores["gameweek"]
+    assert_operator scores["upcoming"], :<, scores["season"]
+  end
+
+  # Five fixtures rather than five times one: the same arithmetic the other horizons
+  # use, over a different run, which is what lets a kind or cruel run show up at all.
+  test "its total is about the window's worth of the coming week" do
+    WeeklyForecast.call(gameweek: @weeks.first)
+    UpcomingForecast.call(gameweek: @weeks.first)
+
+    weekly = Forecast.find_by(player: @player, horizon: "gameweek").score.to_f
+    upcoming = Forecast.find_by(player: @player, horizon: "upcoming").score.to_f
+
+    assert_in_delta weekly * Horizon::WINDOW, upcoming, weekly * Horizon::WINDOW * 0.35
+  end
+
+  # In May there is no five-week run left, and the horizon has to mean whatever is
+  # actually there rather than refusing or reaching for weeks that do not exist.
+  test "a season with less football left than the window forecasts what is there" do
+    Gameweek.where("fpl_id > 3").destroy_all
+
+    UpcomingForecast.call(gameweek: @weeks.first)
+
+    assert_equal [ 1, 2, 3 ], Horizon.new("upcoming").gameweeks.pluck(:fpl_id)
+    assert_not_nil Forecast.find_by(player: @player, horizon: "upcoming")
+  end
+end


### PR DESCRIPTION
A third distance to read a forecast at: the next five gameweeks, which is the run a
transfer is actually made over. The weekly view answers who to captain and the season
view answers who to hold; neither answered who to buy.

## It earns its place, and the data says where

Against the weekly list it re-ranks 6–9 of every top ten. Against the season list:

```
forward      1/10 differ    ← almost the season list already
midfielder   7/10
defender     8/10
goalkeeper   5/10
```

Attacking returns are dominated by the player; clean sheets are dominated by the
opponent. So this horizon is worth most exactly where managers already think hardest
about fixture runs, and adds least for strikers.

Fixtures are genuinely priced in, with a 33% spread between the kindest and cruellest
runs over GW1–5:

```
ARS  0.837          upcoming ÷ (5 × weekly)
BOU  1.118
```

If fixtures were ignored every team would read 1.000.

## It is also the least naive horizon we have

The season forecast's own comment concedes it is "progressively less honest the
further ahead you read" — today's form, price and availability applied to May. Over
five weeks that snapshot is still broadly true, so the same arithmetic does far less
pretending here than it does there.

## The refactor that had to come first

Everywhere asked `season?` and inferred from a no that it must be a single week. That
held with two horizons and broke silently with three: `season? ? remaining_count : 1`
appeared in four unrelated files, so a five-gameweek total was divided by one and
printed under a label reading "expected points this gameweek".

`Horizon` now owns the run of gameweeks it spans, and everything else asks it:

```
the forecaster   which fixtures am I reading?
the grader       how many weeks is this spread over?
the pages        what do I call it?
```

Two of those were wrong numbers rather than wrong words: the rankings card, the player
card and every comparison would have shown a five-week total as a single week's, next
to grades calibrated for one.

## The number lives in one place

Every label carrying "5" is written from `Horizon::WINDOW`. Neither the stored key
(`upcoming`) nor the address (`/upcoming/:position`) carries it, so moving the window
to four renames nothing and redirects nothing.

```
label   Gameweek 1  ·  Next 5 Gameweeks  ·  Rest of Season
phone   GW1         ·  Next 5            ·  Season
```

Three options do not fit a phone at full length, so they use the short-name mechanism
the positions already use, with the full name kept as the accessible one.

## Where it appears

Rankings, squad, player page, comparison, their cards, and the sitemap. Not the
captain page: you captain a player for a gameweek or you do not.

## Worth knowing before merge

- **No migration.** `horizon` is a plain string with a unique index; a third value just
  stores. The keys stay `gameweek / upcoming / season`.
- **Empty for up to an hour after deploy.** Nothing has written an `upcoming` forecast
  or squad on production yet, so `/upcoming/:position` and `/squad/upcoming` will be
  their empty states, and `/squad/upcoming.png` a 404, until the hourly pipeline runs.
  The toggle will offer a third option that leads somewhere empty in that window.
- **The sitemap grew by five URLs** pointing at those pages. Worth deciding whether they
  should wait until they have something on them.
- **The hourly run gets longer**: a third forecast pass plus a third squad search, about
  eight seconds for the search.

427 tests and 13 system tests green, RuboCop, Brakeman and the importmap audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCW3VSRzFyLEDos3sumPfX
