### PR TITLE
Read early-season form properly: both seasons at once, minutes that count, and a run measured against something

### DIFF
--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -20,6 +20,7 @@ class ExpectedPoints < ApplicationService
     expected_goals_per_90 expected_goal_involvements_per_90 clean_sheets_per_90 saves_per_90
     expected_goals_conceded_per_90 defensive_contribution_per_90
     selected_by_percent transfers_in transfers_out now_cost form points_per_game season_bonus
+    last_season_points
     expected_assists_per_90
     last_season_expected_assists_per_90
     last_season_expected_goals_per_90 last_season_expected_goal_involvements_per_90
@@ -183,6 +184,11 @@ class ExpectedPoints < ApplicationService
   # than what happened before. See #form_swing.
   FORM_SWING = 0.2
   FORM_SWING_GROWTH = 0.3
+
+  # How many matches FPL's thirty-day form window holds once it is full, which is
+  # the four games the fifth above was chosen for. Before it is full it holds
+  # fewer, and is trusted for less. See #window_filled.
+  FORM_WINDOW = 4.0
 
   # How much the opponent matters, which depends entirely on what a player is
   # paid for.
@@ -442,9 +448,28 @@ class ExpectedPoints < ApplicationService
     PRICE_POWER - (PRICE_POWER - PRICE_POWER_FLOOR) * season_progress
   end
 
-  # A fifth at the start, widening as the running becomes the evidence.
+  # A fifth once there is a month of running to read, widening from there as the
+  # running becomes the evidence, and narrow while the window is nearly empty.
   def form_swing
-    FORM_SWING + FORM_SWING_GROWTH * season_progress
+    (FORM_SWING + FORM_SWING_GROWTH * season_progress) * window_filled
+  end
+
+  # How much football the form window actually holds, from a quarter of it in the
+  # opening week to all of it a month in.
+  #
+  # A fifth is the right figure for four games, which is what FORM_SWING was
+  # chosen for and what a thirty-day window holds in mid-season. In August it
+  # holds one match, and one match handed a fifth of a player's scoring is a far
+  # louder signal than the one that fifth was priced for. Haaland's quiet opening
+  # afternoon and João Pedro's eleven points both pinned against the edge of the
+  # band, so a single week of football moved the two best forwards in the game a
+  # fifth apart in opposite directions.
+  #
+  # So the band opens as the window fills. It is the same argument as
+  # UNPROVEN_MINUTES and #credibility, applied to a measurement whose window
+  # happens to be counted in days rather than in minutes played.
+  def window_filled
+    (@gameweeks_played / FORM_WINDOW).clamp(0.0, 1.0)
   end
 
   # How much football there has been to measure against. Before the season starts
@@ -662,15 +687,7 @@ class ExpectedPoints < ApplicationService
     record = regular_share(ranking)
     return nil if record.nil?
 
-    [ new_club_cap(record, ranking), backed_share(ranking) ].max
-  end
-
-  # A signing's minutes were earned on somebody else's team sheet, so his record
-  # is held to half a match until he has played some football at this club.
-  def new_club_cap(record, ranking)
-    return record unless @movers.include?(ranking.player_id)
-
-    [ record, @new_club_minutes ].min
+    [ record, backed_share(ranking) ].max
   end
 
   # How much of a match his record says he plays: this season's answer, or last
@@ -690,11 +707,27 @@ class ExpectedPoints < ApplicationService
   # better of the two claims stands, and last season's fades. See #remembered.
   def regular_share(ranking)
     now = share_of(minutes_now(ranking), regular_minutes)
-    before = share_of(minutes_before(ranking), PROVEN_MINUTES)
+    before = new_club_cap(share_of(minutes_before(ranking), PROVEN_MINUTES), ranking)
     return now if before.nil?
 
     remembered_share = before * remembered
     now.nil? ? remembered_share : [ now, remembered_share ].max
+  end
+
+  # A signing's minutes at his old club were earned on somebody else's team
+  # sheet, so they are held to half a match. What he has played at this one is
+  # not held to anything: those minutes are the very evidence the cap is waiting
+  # for.
+  #
+  # The cap used to fall on the finished record, which meant it fell on both, and
+  # a signing who had walked straight into his new side was still held to a
+  # figure that only made sense for the club he had left. Tzolis started for
+  # Arsenal and played seventy-five minutes of it, and was forecast sixty-three:
+  # his own answer, from this club, was capped by a doubt about a different one.
+  def new_club_cap(before, ranking)
+    return before if before.nil? || !@movers.include?(ranking.player_id)
+
+    [ before, @new_club_minutes ].min
   end
 
   # How much last season's team sheet still counts for, from all of it before a
@@ -927,11 +960,76 @@ class ExpectedPoints < ApplicationService
   # Nought before a ball is kicked, and nought for a player with no record, both of
   # which read as no opinion rather than as a slump.
   def form_factor(ranking)
-    recent = stat(ranking, "form")
-    usual = stat(ranking, "points_per_game")
-    return 1.0 if recent.zero? || usual.zero?
+    ratio = form_ratio(ranking)
+    return 1.0 if ratio.nil?
 
-    (recent / usual).clamp(1 - form_swing, 1 + form_swing)
+    (ratio / typical_ratio).clamp(1 - form_swing, 1 + form_swing)
+  end
+
+  # How his recent run compares with his usual level. No opinion where either
+  # figure is missing.
+  def form_ratio(ranking)
+    recent = stat(ranking, "form")
+    usual = usual_scoring(ranking)
+    return nil if recent.zero? || usual.zero?
+
+    recent / usual
+  end
+
+  # The middle of that comparison across everybody he is ranked against.
+  #
+  # A short window sits below a season's average for almost everyone, because a
+  # gameweek's scoring is a few hauls and a great many blanks: the middle
+  # gameweek is worth less than the mean one. Read straight against a season
+  # figure, one week of football marked four players in five out of form, the
+  # median landed on the floor of the swing, and what was meant to be a
+  # comparison became a flat deduction.
+  #
+  # So the ratio is read against the middle of the same ratio for his position,
+  # which is what makes this a form signal rather than a statement about the
+  # shape of the distribution. Being in form means scoring more than the players
+  # around you are scoring, and that is now what it measures. It also needs no
+  # unwinding later: as the season lengthens the window and the average converge,
+  # the middle drifts to one on its own, and this stops doing anything.
+  #
+  # Calibrated on the field and not on the player, for the same reason as
+  # ASSIST_AWARDED above.
+  def typical_ratio
+    return @typical_ratio if defined?(@typical_ratio)
+
+    ratios = @rankings.filter_map { |other| form_ratio(other) }
+    @typical_ratio = ratios.empty? ? 1.0 : middle_of(ratios)
+  end
+
+  # What he normally scores, which is the thing a recent run is read against.
+  #
+  # This used to be FPL's points_per_game, and for the first month of a season
+  # that is not a baseline at all: points_per_game is this season's average and
+  # form is the last thirty days, and early on they are the same football. They
+  # divided to exactly one for all 292 players who had a record at the second
+  # gameweek, so the swing above was multiplying by nothing for a month, in the
+  # very window where a manager most wants to know who has started well.
+  #
+  # So the baseline is what he scored last season, which cannot move with the
+  # numerator, and it fades across to this season's average as the campaign grows
+  # long enough to be a different window from the form. See #remembered.
+  #
+  # Last season is read per 90 and FPL's form is per appearance, which are the
+  # same number for a man who plays whole games and not for a substitute, whose
+  # run therefore reads a little cool. The swing is a fifth either way at most, so
+  # the mismatch cannot do much; measuring it properly needs last season's
+  # appearances, which FPL does not publish on this endpoint.
+  def usual_scoring(ranking)
+    blend(optional_stat(ranking, "points_per_game"), last_season_per_90(ranking), 1 - remembered)
+  end
+
+  # What he scored last season, per 90 minutes on the pitch. No opinion where he
+  # did not play it.
+  def last_season_per_90(ranking)
+    played = minutes_before(ranking)
+    return nil if played.nil? || played.zero?
+
+    stat(ranking, "last_season_points") / (played / FULL_MATCH)
   end
 
   def goal_points(ranking)

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -21,20 +21,22 @@ class ExpectedPoints < ApplicationService
     expected_goals_conceded_per_90 defensive_contribution_per_90
     selected_by_percent transfers_in transfers_out now_cost form points_per_game season_bonus
     expected_assists_per_90
+    last_season_expected_assists_per_90
     last_season_expected_goals_per_90 last_season_expected_goal_involvements_per_90
     last_season_clean_sheets_per_90 last_season_saves_per_90 last_season_bonus
     last_season_expected_goals_conceded_per_90 last_season_defensive_contribution_per_90
   ].freeze
 
-  # Where each measurement is read from before a ball is kicked.
+  # Which figure is the same measurement taken last season.
   #
-  # All of these describe the same football, so they have to come from the same
-  # season. Take a player's minutes from last season and his scoring rate from a
-  # season he spent outside the league and he is credited with a full campaign of
-  # turning up and doing nothing, which is how a promoted club's defender came to
-  # outrank the man half the game had picked ahead of him. FPL also zeroes the
-  # current-season fields over the summer, so reading them then hands every player
-  # in the game the same bare appearance points.
+  # All of these describe the same football, so a figure and its pair have to be
+  # read together. Take a player's minutes from last season and his scoring rate
+  # from a season he spent outside the league and he is credited with a full
+  # campaign of turning up and doing nothing, which is how a promoted club's
+  # defender came to outrank the man half the game had picked ahead of him.
+  #
+  # This was once a switch: last season until the first whistle, this season from
+  # then on. It is now the far side of a blend. See #record.
   LAST_SEASON = {
     "season_minutes" => "last_season_minutes",
     "season_bonus" => "last_season_bonus",
@@ -633,13 +635,32 @@ class ExpectedPoints < ApplicationService
   # unknown rather than expected to do nothing, and unknown must not be ranked as
   # though we had measured it.
   def minutes_share(ranking)
-    played = minutes_played(ranking)
-    return nil if played.nil?
-
-    regular = [ played / regular_minutes, 1.0 ].min
+    regular = regular_share(ranking)
+    return nil if regular.nil?
     return regular unless @movers.include?(ranking.player_id)
 
     [ [ regular, @new_club_minutes ].min, settled_in(ranking) ].max
+  end
+
+  # How much of a match his record says he plays, from both seasons at once.
+  #
+  # Each season is read against its own denominator, because that is what each is
+  # a share of: this season against the football there has actually been, last
+  # season against a regular's campaign. Then they blend like any other figure.
+  def regular_share(ranking)
+    now = share_of(minutes_now(ranking), regular_minutes)
+    before = share_of(minutes_before(ranking), PROVEN_MINUTES)
+    return nil if now.nil? && before.nil?
+
+    blend(now, before, settled(ranking))
+  end
+
+  # What those minutes are as a share of the season they were played in, or no
+  # opinion where that season was never played.
+  def share_of(minutes, season)
+    return nil if minutes.nil?
+
+    [ minutes / season, 1.0 ].min
   end
 
   # What a signing's backing says about the team sheet. See NAILED_ON.
@@ -709,17 +730,54 @@ class ExpectedPoints < ApplicationService
     minutes_share(ranking).to_f
   end
 
-  def minutes_played(ranking)
-    optional_stat(ranking, season_or_last("season_minutes"))
+  # How much football we have watched him play, this season and last. Either may
+  # be silent: a promoted player has no last season in this league, and nobody
+  # has a this season until a ball is kicked.
+  def minutes_now(ranking)
+    optional_stat(ranking, "season_minutes")
   end
 
-  # What he did, read from whichever season we are measuring. See LAST_SEASON.
+  def minutes_before(ranking)
+    optional_stat(ranking, "last_season_minutes")
+  end
+
+  # How far this season has taken over from last, nought in August and most of
+  # the way across by the time a record can stand on its own.
+  #
+  # The five matches of doubt again, doing the job they were always shaped for.
+  # Read against UNPROVEN_MINUTES a record crosses halfway through its fifth
+  # match, which is about when a run of starts stops looking like a run of luck.
+  def settled(ranking)
+    played = minutes_now(ranking).to_f
+    played / (played + UNPROVEN_MINUTES)
+  end
+
+  # What he does, from both seasons at once, this season leading as it grows.
+  #
+  # This used to be a switch, and a switch is right twice a year and wrong for the
+  # month after. At the second gameweek it threw away Haaland's three thousand
+  # minutes in order to read the ninety that had replaced them, then shrank those
+  # ninety by four fifths for being thin, and his per-90 fell from seven points to
+  # under three. The two seasons did not even disagree: 0.78 expected goals a game
+  # against 0.74. We were discarding the evidence that said the same thing as the
+  # evidence we kept, and calling the remainder doubtful.
+  #
+  # So the two are blended, weighted by how much of this season there is to read.
+  # Either side may be silent, and silence is no opinion rather than a nought: a
+  # promoted player is read on this season alone, and an August on last.
   def record(ranking, type)
-    stat(ranking, season_or_last(type))
+    blend(optional_stat(ranking, type), optional_stat(ranking, LAST_SEASON.fetch(type)),
+          settled(ranking))
   end
 
-  def season_or_last(type)
-    @season_started ? type : LAST_SEASON.fetch(type)
+  # Two readings of the same thing, weighed by how far this season has taken over
+  # from last. Either may be silent, and a silence is no opinion rather than a
+  # nought: what the other one says stands unaltered.
+  def blend(now, before, settled)
+    return before.to_f if now.nil?
+    return now.to_f if before.nil?
+
+    now * settled + before * (1 - settled)
   end
 
   def regular_minutes
@@ -796,10 +854,18 @@ class ExpectedPoints < ApplicationService
   # five matches of doubt instead, and one bonus point off the bench stays worth
   # about what it was.
   def bonus_points(ranking)
-    played = minutes_played(ranking).to_f
-    return 0.0 if played.zero?
+    blend(bonus_rate(ranking, "season_bonus", minutes_now(ranking)),
+          bonus_rate(ranking, "last_season_bonus", minutes_before(ranking)),
+          settled(ranking))
+  end
 
-    record(ranking, "season_bonus") / ([ played, UNPROVEN_MINUTES ].max / FULL_MATCH)
+  # One season's bonus as a rate per 90, so the two campaigns meet as rates and
+  # not as totals. Forty-three bonus points off a full season and none off one
+  # quiet afternoon are not two numbers that can be averaged.
+  def bonus_rate(ranking, type, played)
+    return nil if played.nil? || played.zero?
+
+    stat(ranking, type) / ([ played, UNPROVEN_MINUTES ].max / FULL_MATCH)
   end
 
   # Nought before a ball is kicked, and nought for a player with no record, both of
@@ -1021,10 +1087,17 @@ class ExpectedPoints < ApplicationService
   # meant to. One match is precisely the evidence UNPROVEN_MINUTES exists to
   # distrust.
   def credibility(ranking)
-    played = minutes_played(ranking).to_f
+    played = football_seen(ranking)
     ceiling = PROVEN_MINUTES / (PROVEN_MINUTES + UNPROVEN_MINUTES)
 
     ((played / (played + UNPROVEN_MINUTES)) / ceiling).clamp(0.0, 1.0)
+  end
+
+  # Every minute we have watched him play, this season and last, because a rate is
+  # only ever doubted for the football behind it. A man with a full campaign
+  # behind him does not become an unknown quantity because a new season started.
+  def football_seen(ranking)
+    minutes_now(ranking).to_f + minutes_before(ranking).to_f
   end
 
   # THE THIRD TERM: the games in front of him, each counted for what it is worth

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -78,20 +78,31 @@ class ExpectedPoints < ApplicationService
   # rest-of-season horizon lifts the cap so his record does more of the talking.
   NEW_CLUB_MINUTES = 0.5
 
-  # How much of the game has to own a new signing before we take it that he has
-  # walked into the side.
+  # How much of the game has to own a player before we take it that he is in the
+  # side.
   #
-  # The cap above is an admission that we do not know whether he starts, and that
-  # is the one question the crowd answers better than any record can: managers do
-  # not spend a squad place on a man who sits out. So where we have said "his
-  # minutes belong to another club's team sheet", their money is allowed to say
-  # "and he is first choice at this one".
+  # A thin minutes record is an admission that we do not know whether he starts,
+  # and that is the one question the crowd answers better than any record can:
+  # managers do not spend a squad place on a man who sits out. So where a record
+  # cannot say whether he is first choice, their money is allowed to.
   #
-  # It is deliberately the narrowest use we could make of ownership. It applies
-  # only where we have already confessed to guessing, it can only lift a player
-  # and never mark him down, and it stops at a regular's share: backing may
-  # establish that a man plays, never that he is any good, which is what his
-  # record is for.
+  # This once applied to new signings alone, on the grounds that a signing is the
+  # only player we have confessed to guessing about. Giving minutes their real
+  # force widened that confession to anyone whose record is thin, whatever thinned
+  # it. Isak had 784 minutes behind him, a ninth of the game holding him at nine
+  # million, and a record that could only argue he plays four tenths of a match:
+  # the money knew he was first choice and had no way of saying so, and he fell
+  # from fourth in his position to twenty-second.
+  #
+  # It stays the narrowest use we can make of ownership. It can only lift a player
+  # and never mark him down, so a full record is left entirely alone. It stops at
+  # a regular's share: backing may establish that a man plays, never that he is any
+  # good, which is what his record is for. And it is discounted at the cheap end,
+  # where owning a player is half a decision because somebody had to fill the slot
+  # and the game piles into whichever cheap man is nailed on. That discount is what
+  # separates the two players this is meant to tell apart: Isak at nine million,
+  # lifted, from Kusi-Asare at four and a half with no minutes at all, who is not.
+  # See CHEAP_BAND.
   #
   # A tenth of the game is a lot of managers when the average player is owned by
   # two per cent of it. A starting figure, to be settled by what actually happens
@@ -462,29 +473,42 @@ class ExpectedPoints < ApplicationService
 
   private
 
+  # Minutes multiply the answer the two estimates settle on, instead of sitting
+  # inside one of them.
+  #
+  # They used to sit inside ours, and could not survive the journey out. The
+  # crowd's estimate carries no minutes of its own, and a record is only let nudge
+  # the crowd by a few percent, so at the second gameweek playing no football at
+  # all cost a well-owned man five percent: Watkins was our thirteenth best
+  # forward on an estimate of exactly nought, while McBurnie, who had played the
+  # full ninety, stood twenty-first. The first of the three terms this model is
+  # built on was the one term it could not hear.
+  #
+  # So both estimates now price the same thing, which is what a player is worth
+  # per 90 on the pitch, and everything deciding whether he is on it to earn that
+  # multiplies afterwards: how much of the match he plays, whether he is fit for
+  # it, how many games are in front of him, and what this week's traffic says.
   def forecast(ranking)
     ours = our_estimate(ranking)
     theirs = crowd_estimate(ranking)
     return { points: nil, working: {} } if ours.nil? && theirs.nil?
 
-    points = blended(ranking, ours, theirs) * starting_share(ranking) *
+    points = blended(ranking, ours, theirs) * played_share(ranking) *
              availability(ranking) * games_ahead(ranking) * transfer_factor(ranking)
     { points: points, working: working_for(ranking, ours, theirs) }
   end
 
-  # What a player is worth in a single game, before the fixture and before this
-  # week's news. Nil when there is no record to read.
+  # What a player is worth per 90 minutes on the pitch, before the fixture and
+  # before this week's news. Nil when there is no record to read at all, because
+  # unknown must not be ranked as though we had measured it.
   #
-  # A goalkeeper is worth what he is worth per 90, with no minutes in it. His
-  # minutes are a chance of playing rather than a share of a match, and a chance
-  # cannot be argued down by a few percent the way a rate can, so it is applied to
-  # the finished answer instead. See #starting_share.
+  # No minutes in it, for anybody. What the crowd and the record disagree about is
+  # how good he is; how much he plays is not a matter for either of them to argue
+  # and is applied to the finished answer instead. See #forecast.
   def our_estimate(ranking)
-    share = minutes_share(ranking)
-    return nil if share.nil?
-    return points_per_90(ranking) if goalkeeper?(ranking)
+    return nil if minutes_share(ranking).nil?
 
-    share * points_per_90(ranking)
+    points_per_90(ranking)
   end
 
   # What a player standing where he stands with the crowd is typically worth, read
@@ -635,24 +659,57 @@ class ExpectedPoints < ApplicationService
   # unknown rather than expected to do nothing, and unknown must not be ranked as
   # though we had measured it.
   def minutes_share(ranking)
-    regular = regular_share(ranking)
-    return nil if regular.nil?
-    return regular unless @movers.include?(ranking.player_id)
+    record = regular_share(ranking)
+    return nil if record.nil?
 
-    [ [ regular, @new_club_minutes ].min, settled_in(ranking) ].max
+    [ new_club_cap(record, ranking), backed_share(ranking) ].max
   end
 
-  # How much of a match his record says he plays, from both seasons at once.
+  # A signing's minutes were earned on somebody else's team sheet, so his record
+  # is held to half a match until he has played some football at this club.
+  def new_club_cap(record, ranking)
+    return record unless @movers.include?(ranking.player_id)
+
+    [ record, @new_club_minutes ].min
+  end
+
+  # How much of a match his record says he plays: this season's answer, or last
+  # season's while that is still worth remembering.
   #
   # Each season is read against its own denominator, because that is what each is
   # a share of: this season against the football there has actually been, last
-  # season against a regular's campaign. Then they blend like any other figure.
+  # season against a regular's campaign.
+  #
+  # They are not blended, though, and that is the one place a minutes share parts
+  # company with every rate above it. A rate is a noisy measurement of something
+  # that holds still, so a thin one is properly dragged towards a fuller one. A
+  # share of minutes is a claim about a player's role, and a role is exactly the
+  # thing a summer changes. Blended, Isak's full ninety minutes in the opening week
+  # counted for a sixth of the answer and an injury-hit campaign for the rest, and
+  # a fit first-choice striker was forecast to play two thirds of a match. So the
+  # better of the two claims stands, and last season's fades. See #remembered.
   def regular_share(ranking)
     now = share_of(minutes_now(ranking), regular_minutes)
     before = share_of(minutes_before(ranking), PROVEN_MINUTES)
-    return nil if now.nil? && before.nil?
+    return now if before.nil?
 
-    blend(now, before, settled(ranking))
+    remembered_share = before * remembered
+    now.nil? ? remembered_share : [ now, remembered_share ].max
+  end
+
+  # How much last season's team sheet still counts for, from all of it before a
+  # ball is kicked to none of it a month in.
+  #
+  # It has to fade on the football there has been rather than on the football he
+  # has played, because the player it protects is the one who is not playing.
+  # Weighed by his own minutes, a man who has been dropped never accumulates the
+  # evidence that would retire last year's record, and it speaks for him all
+  # season.
+  #
+  # Five matches, the same five UNPROVEN_MINUTES doubts a rate for: a month of
+  # team sheets settles what a player's role is.
+  def remembered
+    (1 - @gameweeks_played / (UNPROVEN_MINUTES / FULL_MATCH)).clamp(0.0, 1.0)
   end
 
   # What those minutes are as a share of the season they were played in, or no
@@ -663,16 +720,15 @@ class ExpectedPoints < ApplicationService
     [ minutes / season, 1.0 ].min
   end
 
-  # What a signing's backing says about the team sheet. See NAILED_ON.
-  def settled_in(ranking)
-    REGULAR_SHARE * (ownership(ranking) / NAILED_ON).clamp(0.0, 1.0)
+  # What the game's money says about whether he is in the side, discounted at the
+  # cheap end where owning a man says less about him. See NAILED_ON.
+  def backed_share(ranking)
+    REGULAR_SHARE * (ownership(ranking) / NAILED_ON).clamp(0.0, 1.0) *
+      (1 - cheapness(ranking))
   end
 
-  # A goalkeeper's chance of being the one his club picks. One for everybody else,
-  # whose minutes are already inside his own estimate. See KEEPER_BACKING.
+  # A goalkeeper's chance of being the one his club picks. See KEEPER_BACKING.
   def starting_share(ranking)
-    return 1.0 unless goalkeeper?(ranking)
-
     club_shares(ranking.team_id)[ranking.player_id] || 0.0
   end
 
@@ -721,9 +777,9 @@ class ExpectedPoints < ApplicationService
     ranking.position == GOALKEEPER
   end
 
-  # How much of a match he is expected to be on the pitch for, whichever way the
-  # model arrived at it. Reported rather than scored: it is the figure that
-  # actually multiplied his answer, so the page and the arithmetic agree.
+  # How much of a match he is expected to be on the pitch for. A share of one for
+  # an outfield player, and for a goalkeeper the chance he is the one his club
+  # picks, that being the same question asked of a place which cannot be shared.
   def played_share(ranking)
     return starting_share(ranking) if goalkeeper?(ranking)
 

--- a/app/services/forecaster.rb
+++ b/app/services/forecaster.rb
@@ -29,7 +29,12 @@ class Forecaster < ApplicationService
   #    counted rather than expected, a clean sheet is the chance of one rather than
   #    the share he happened to keep, saves are paid in whole threes, and a full
   #    season of evidence stops being shrunk for doubt it has already answered.
-  MODEL = 4
+  # 5: a season is a dial rather than a switch. What a player does is read from
+  #    this season and last at once, weighted by how much of this one there is,
+  #    instead of swapping wholesale at the first whistle and distrusting what
+  #    replaced it. Last season's expected assists are read at all, having been
+  #    mapped but never loaded.
+  MODEL = 5
 
   def initialize(gameweek: nil)
     @gameweek = gameweek || Gameweek.next_gameweek

--- a/app/services/forecaster.rb
+++ b/app/services/forecaster.rb
@@ -34,7 +34,13 @@ class Forecaster < ApplicationService
   #    instead of swapping wholesale at the first whistle and distrusting what
   #    replaced it. Last season's expected assists are read at all, having been
   #    mapped but never loaded.
-  MODEL = 5
+  # 6: minutes multiply the answer rather than sitting inside our half of it, so
+  #    the first of the three terms can be heard at all; and a thin minutes record
+  #    may be lifted by what the game has paid to own him, discounted at the cheap
+  #    end, rather than only where he has changed clubs. Last season's minutes are
+  #    remembered and fade over a month rather than being blended in, a role being
+  #    the one thing a summer changes.
+  MODEL = 6
 
   def initialize(gameweek: nil)
     @gameweek = gameweek || Gameweek.next_gameweek

--- a/app/services/forecaster.rb
+++ b/app/services/forecaster.rb
@@ -40,7 +40,15 @@ class Forecaster < ApplicationService
   #    end, rather than only where he has changed clubs. Last season's minutes are
   #    remembered and fade over a month rather than being blended in, a role being
   #    the one thing a summer changes.
-  MODEL = 6
+  # 7: a recent run is read against what a player scored last season rather than
+  #    against this season's average, which early on is the same thirty days as
+  #    the run itself and divided to exactly one for everybody. The run is read
+  #    against the field rather than in the absolute, a short window sitting below
+  #    a season average for almost everybody, and how far it may swing a player
+  #    opens as the window fills rather than being a fifth from the first week. A
+  #    signing's new-club cap falls on the minutes he played elsewhere and not on
+  #    the ones he has played here.
+  MODEL = 7
 
   def initialize(gameweek: nil)
     @gameweek = gameweek || Gameweek.next_gameweek

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -573,15 +573,21 @@ class ExpectedPointsTest < ActiveSupport::TestCase
            "a wider band lets his ordinary record pull him back down toward it"
   end
 
-  test "a dear, well-backed player the record has barely seen outranks a cheap one it knows well" do
+  # A dear player whose season was cut short must not be written off for the
+  # record it left him. He no longer beats a cheaper man with a full campaign
+  # behind him, which he did while minutes could not reach the answer and the
+  # market decided nearly everything. What his price and his backing buy him now
+  # is a place on the team sheet, and that is measured against the same player
+  # nobody has bought.
+  test "a dear, well-backed player is not written off for the season that cut his record short" do
     rankings, stats = crowded_field(owned: [ 12.0, 22.0 ], cost: [ 90.0, 55.0 ])
-    stats[1] = regular(minutes: 700.0, xg: 0.30, xgi: 0.45, owned: 12.0, cost: 90.0) # injured last year, still dear
-    stats[2] = regular(minutes: 3000.0, xg: 0.35, xgi: 0.55, owned: 22.0, cost: 55.0) # cheap, healthy, well-owned
+    thin = regular(minutes: 700.0, xg: 0.30, xgi: 0.45, cost: 90.0)
 
-    result = forecast(rankings, stats)
+    backed = forecast(rankings, stats.merge(1 => thin.merge("selected_by_percent" => 12.0)))
+    ignored = forecast(rankings, stats.merge(1 => thin.merge("selected_by_percent" => 0.3)))
 
-    assert result[1][:points] > result[2][:points],
-           "what he costs remembers the season his thin record has forgotten"
+    assert_operator backed[1][:points], :>, ignored[1][:points] * 1.5,
+                    "what the game paid to own him says he starts, where seven hundred minutes cannot"
   end
 
   test "a recent run counts for more as the season runs" do
@@ -617,10 +623,15 @@ class ExpectedPointsTest < ActiveSupport::TestCase
 
   # Two signings with the same thin record at their old clubs. The only thing
   # separating them is how much of the game has already picked them.
+  #
+  # A cheap man stands with them to give the position a floor. What owning a
+  # player says about him depends on how far above the floor he was bought, and a
+  # field of a single price has nothing to measure that from. See CHEAP_BAND.
   def two_signings(owned:)
-    rankings = [ ranking(1), ranking(2) ]
+    rankings = [ ranking(1), ranking(2), ranking(3) ]
     stats = { 1 => regular(minutes: 800.0, owned: owned.first),
-              2 => regular(minutes: 800.0, owned: owned.last) }
+              2 => regular(minutes: 800.0, owned: owned.last),
+              3 => regular(owned: 1.0, cost: 45.0) }
     [ rankings, stats ]
   end
 
@@ -635,8 +646,9 @@ class ExpectedPointsTest < ActiveSupport::TestCase
   end
 
   test "backing can establish that a signing plays, never that he is any good" do
-    rankings = [ ranking(1) ]
-    stats = { 1 => regular(minutes: 3000.0, owned: 90.0) } # adored, and a full record elsewhere
+    rankings = [ ranking(1), ranking(2) ]
+    stats = { 1 => regular(minutes: 3000.0, owned: 90.0), # adored, and a full record elsewhere
+              2 => regular(owned: 1.0, cost: 45.0) }      # a floor to read his price against
 
     result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
                                  season_started: false, movers: [ 1 ])
@@ -644,14 +656,31 @@ class ExpectedPointsTest < ActiveSupport::TestCase
     assert_equal 63, result[1][:working][:minutes], "it stops at a regular's share, not a full match"
   end
 
-  test "a settled player's minutes are his own business, however many own him" do
+  test "a full record is a player's own business, however many own him" do
     rankings, stats = two_signings(owned: [ 40.0, 0.4 ])
+    stats[1] = regular(minutes: 3000.0, owned: 40.0)
+    stats[2] = regular(minutes: 3000.0, owned: 0.4)
 
     result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
                                  season_started: false, movers: [])
 
     assert_equal result[2][:working][:minutes], result[1][:working][:minutes],
-                 "ownership only answers the question the new-club cap asks"
+                 "backing lifts a thin record and has nothing to add to a full one"
+  end
+
+  test "a thin record is lifted by what the game paid to own him, and not at the floor" do
+    rankings = [ ranking(1), ranking(2), ranking(3) ]
+    stats = { 1 => regular(minutes: 780.0, owned: 17.0, cost: 90.0), # a premium who missed most of last year
+              2 => regular(minutes: 780.0, owned: 17.0, cost: 45.0), # the same record, at the floor
+              3 => regular(owned: 1.0, cost: 45.0) }
+
+    result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: false, movers: [])
+
+    assert_equal 63, result[1][:working][:minutes],
+                 "the money says he is first choice where seven hundred minutes cannot"
+    assert_operator result[2][:working][:minutes], :<, 35,
+                    "the same backing at the floor of a position is somebody filling a slot"
   end
 
   test "a rush for the exit drops a player hard and at once" do

--- a/test/services/expected_points_test.rb
+++ b/test/services/expected_points_test.rb
@@ -590,19 +590,38 @@ class ExpectedPointsTest < ActiveSupport::TestCase
                     "what the game paid to own him says he starts, where seven hundred minutes cannot"
   end
 
-  test "a recent run counts for more as the season runs" do
+  # A run only means anything measured against the runs everybody else is having,
+  # so the field is ordinary and he is not. See ExpectedPoints#typical_ratio.
+  def hot_among_ordinary
     hot = { "season_minutes" => 3000.0, "expected_goals_per_90" => 0.30,
             "expected_goal_involvements_per_90" => 0.50, "clean_sheets_per_90" => 0.30,
             "selected_by_percent" => 5.0, "now_cost" => 60.0,
             "form" => 8.0, "points_per_game" => 4.0 } # in the middle of a hot streak
+    stats = (2..5).index_with { hot.merge("form" => 4.0) }.merge(1 => hot)
+    [ (1..5).map { |id| ranking(id) }, stats ]
+  end
 
-    early = ExpectedPoints.call([ ranking(1) ], stats: { 1 => hot }, fixtures_by_team: { 1 => [ fixture ] },
+  test "a recent run counts for more as the season runs" do
+    rankings, stats = hot_among_ordinary
+
+    early = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
                                 season_started: true, gameweeks_played: 2)
-    late = ExpectedPoints.call([ ranking(1) ], stats: { 1 => hot }, fixtures_by_team: { 1 => [ fixture ] },
+    late = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
                                season_started: true, gameweeks_played: 30)
 
     assert late[1][:points] > early[1][:points],
            "his hot streak is let say more once there is a season of it to trust"
+  end
+
+  test "a run is read against the runs everybody else is having" do
+    rankings, stats = hot_among_ordinary
+
+    result = ExpectedPoints.call(rankings, stats: stats, fixtures_by_team: { 1 => [ fixture ] },
+                                 season_started: true, gameweeks_played: 2)
+
+    assert_operator result[1][:working][:form], :>, 1.0, "he is scoring more than the field is"
+    assert_equal 1.0, result[2][:working][:form],
+                 "and a player scoring exactly what the field scores is neither hot nor cold"
   end
 
   test "an established signing is held to half a match, and a longer horizon eases that" do


### PR DESCRIPTION
Assessed how well the model caters for early-season form at GW2, then fixed what the assessment found. Three commits, `MODEL` 4 → 7.

## What was wrong

At the second gameweek the model was effectively blind to the season it was in:

- **A season was a switch, not a dial.** At GW1 it discarded last season wholesale, then shrank the 90 minutes that replaced it by four fifths for being thin. Haaland's per-90 fell from ~7.0 to 2.61 despite the two seasons agreeing (0.78 expected goals a game against 0.74). Consequence: **zero A grades anywhere in the game**, everything crushed into C and D.
- **Minutes could not be heard.** They sat inside our own estimate; the crowd's carries none; a record may only nudge the crowd a few percent. So playing no football at all cost a well-owned player 5%. Watkins was 13th best forward on an estimate of exactly nought; McBurnie, who had played the full 90, was 21st.
- **Form did literally nothing.** `form / points_per_game` divides the last 30 days by this season's average, which early on is the same football. It came out at exactly `1.000` for all 292 players with a record.

## What changed

1. **`0cfd97d`** — both seasons are read at once, weighted by how much of this one there is. Rates are doubted for all the football behind them rather than only this season's. Bonus meets bonus as a rate, not a total. Also fixes a live bug: `last_season_expected_assists_per_90` was mapped but missing from `STAT_TYPES`, so 406 rows sat unread and every pre-season forecast priced creativity at zero.

2. **`fdc5661`** — minutes multiply the finished answer instead of hiding inside one half of it, so both estimates price the same thing (what he's worth per 90) and everything deciding whether he's on the pitch applies afterwards. A thin record may then be lifted by what the game paid to own him, discounted at the floor of a position — which is the whole of what separates Isak at £9.0m (lifted) from Kusi-Asare at £4.5m with no minutes (not). Minutes are *remembered* across seasons rather than blended, fading over five gameweeks, because a role is the one thing a summer changes.

3. **`98b6434`** — a run is measured against last season's scoring rather than against itself, read against the middle of the field rather than in the absolute (a short window sits below a season average for almost everyone, so read straight it marked four players in five out of form), with a band that opens as the window fills rather than handing one match the fifth that was priced for four.

## Effect at GW2

| | before | after |
|---|---|---|
| Haaland | 4th, 2.75 | **2nd, 6.40** |
| Isak | 3rd, 2.84 | **5th, 5.27** (90 mins) |
| Tzolis | 50th | **15th** (90 mins) |
| McBurnie (90 mins played, 1.9% owned) | 21st, 1.24 | **13th, 4.55** |
| Kusi-Asare (0 mins, £4.5m, 7.1% owned) | 18th, 1.92 | **47th, 0.05** |
| A-grades in the whole game | **0** | 64 of 612 |

Goalkeepers moved barely at all, which is the sanity check: they already had minutes applied outside the blend via `starting_share`.

## Review notes

- **Nothing here is verified against results, and it cannot be yet.** Statistics are re-synced hourly onto the row stamped with the current gameweek, so a finished gameweek's own row holds post-match data and re-forecasting it reads the score. A GW1 backtest showed MAE 1.64 → 1.34 and rank correlation 0.46 → 0.63; all of it was hindsight. Fixing that leak is the next priority, because until then `ff:accuracy` cannot compare model versions.
- **Two tests changed their claims**, not just their fixtures: ownership no longer answers only the new-club question, and a dear player the record has barely seen no longer outranks a cheaper one it knows well. Both are deliberate and argued in the commit messages.
- **Known follow-ups:** store `starts` (everyone plays 82–92 minutes when they start, so minutes-per-start carries no information — `backed_share` currently patches around this rather than measuring it); `CLAMP_WIDTH`'s comment now defends a narrow band on grounds these commits made untrue; grade bands were calibrated for the old scale and the scale moved ~1.7x; four stat types are loaded every run and read by nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)