### PR TITLE
Absorb everything FPL publishes, stop two syncs overwriting each other, and drop what the forecast reads for nothing

### DIFF
--- a/app/services/comparison_stats.rb
+++ b/app/services/comparison_stats.rb
@@ -61,11 +61,11 @@ class ComparisonStats < ApplicationService
              label: "Defensive contributions, per 90", better: :high, format: :two),
 
     Stat.new(this: "season_bonus", last: "last_season_bonus", label: "Bonus points", better: :high, format: :whole),
-    Stat.new(this: "bps", last: nil, label: "Bonus points system (BPS)", better: :high, format: :whole),
-    Stat.new(this: "ict_index", last: nil, label: "ICT index", better: :high, format: :one),
-    Stat.new(this: "threat", last: nil, label: "Threat", better: :high, format: :one),
-    Stat.new(this: "creativity", last: nil, label: "Creativity", better: :high, format: :one),
-    Stat.new(this: "influence", last: nil, label: "Influence", better: :high, format: :one),
+    Stat.new(this: "season_bps", last: nil, label: "Bonus points system (BPS)", better: :high, format: :whole),
+    Stat.new(this: "season_ict_index", last: nil, label: "ICT index", better: :high, format: :one),
+    Stat.new(this: "season_threat", last: nil, label: "Threat", better: :high, format: :one),
+    Stat.new(this: "season_creativity", last: nil, label: "Creativity", better: :high, format: :one),
+    Stat.new(this: "season_influence", last: nil, label: "Influence", better: :high, format: :one),
 
     Stat.new(this: "season_penalties_saved", last: nil, label: "Penalties saved", better: :high, format: :whole),
     Stat.new(this: "season_penalties_missed", last: nil, label: "Penalties missed", better: :low, format: :whole),

--- a/app/services/expected_points.rb
+++ b/app/services/expected_points.rb
@@ -15,16 +15,24 @@
 #   stats            - { player_id => { stat_type => Float } }
 #   fixtures_by_team - { team_id => [{ difficulty:, opponent:, home: }] } this week's games
 class ExpectedPoints < ApplicationService
+  # What the forecast reads. Every one of these reaches an answer: a figure that
+  # is loaded and then multiplied by nothing costs a query and an illusion that
+  # the model is weighing something it is not.
+  #
+  # Expected goal involvements and the clean sheet rate used to be here. They went
+  # quiet when creating was priced from expected assists instead of the combined
+  # figure, and when a clean sheet became the chance of one rather than the share
+  # a side happened to keep. Both are still synced and still read by the
+  # comparison page; they are simply no longer read here.
   STAT_TYPES = %w[
     season_minutes last_season_minutes chance_of_playing
-    expected_goals_per_90 expected_goal_involvements_per_90 clean_sheets_per_90 saves_per_90
+    expected_goals_per_90 saves_per_90
     expected_goals_conceded_per_90 defensive_contribution_per_90
     selected_by_percent transfers_in transfers_out now_cost form points_per_game season_bonus
     last_season_points
     expected_assists_per_90
     last_season_expected_assists_per_90
-    last_season_expected_goals_per_90 last_season_expected_goal_involvements_per_90
-    last_season_clean_sheets_per_90 last_season_saves_per_90 last_season_bonus
+    last_season_expected_goals_per_90 last_season_saves_per_90 last_season_bonus
     last_season_expected_goals_conceded_per_90 last_season_defensive_contribution_per_90
   ].freeze
 
@@ -43,8 +51,6 @@ class ExpectedPoints < ApplicationService
     "season_bonus" => "last_season_bonus",
     "expected_assists_per_90" => "last_season_expected_assists_per_90",
     "expected_goals_per_90" => "last_season_expected_goals_per_90",
-    "expected_goal_involvements_per_90" => "last_season_expected_goal_involvements_per_90",
-    "clean_sheets_per_90" => "last_season_clean_sheets_per_90",
     "saves_per_90" => "last_season_saves_per_90",
     "expected_goals_conceded_per_90" => "last_season_expected_goals_conceded_per_90",
     "defensive_contribution_per_90" => "last_season_defensive_contribution_per_90"

--- a/app/services/fpl/sync_performances.rb
+++ b/app/services/fpl/sync_performances.rb
@@ -1,12 +1,29 @@
 module Fpl
   class SyncPerformances < ApplicationService
+    # The key in FPL's per-gameweek history => the statistic type we store it as,
+    # the same direction as SyncPlayers::SNAPSHOT_STATS and
+    # SyncPlayerHistories::STAT_TYPES. Most keep their own name.
     STAT_TYPES = %w[
       total_points minutes goals_scored assists clean_sheets goals_conceded own_goals
       penalties_saved penalties_missed yellow_cards red_cards saves bonus bps
       influence creativity threat ict_index starts expected_goals expected_assists
       expected_goal_involvements expected_goals_conceded clearances_blocks_interceptions
       recoveries tackles defensive_contribution
-    ].freeze
+    ].index_with { |type| type }.merge(
+      # What the game thought of him that week: how many owned him, what he cost,
+      # and which way the traffic ran. The bootstrap snapshot only ever holds the
+      # latest of these, so this is the only place the week-by-week series exists.
+      #
+      # The two transfer figures are named apart because the snapshot already
+      # stores this gameweek's traffic as transfers_in, and the unique index is
+      # player, gameweek and type: left alone, the two syncs would take turns
+      # overwriting one another every hour.
+      "selected" => "selected",
+      "value" => "value",
+      "transfers_balance" => "transfers_balance",
+      "transfers_in" => "gameweek_transfers_in",
+      "transfers_out" => "gameweek_transfers_out"
+    ).freeze
 
     def initialize(gameweek_id = nil, api: Api.new)
       @gameweek_id = gameweek_id
@@ -94,7 +111,7 @@ module Fpl
       return [] unless player
 
       stats = element["stats"] || {}
-      STAT_TYPES.filter_map { |type| build_stat_record(player, gameweek, type, stats[type], now) }
+      STAT_TYPES.filter_map { |key, type| build_stat_record(player, gameweek, type, stats[key], now) }
     end
 
     def build_stat_record(player, gameweek, type, value, now)

--- a/app/services/fpl/sync_player_histories.rb
+++ b/app/services/fpl/sync_player_histories.rb
@@ -10,15 +10,19 @@ module Fpl
   # incremental: players whose totals are already stored are skipped. A re-run
   # costs almost nothing and an interrupted run picks up where it stopped.
   class SyncPlayerHistories < ApplicationService
-    # Statistic type => the key to read from FPL's past-season entry.
+    # The key in FPL's past-season entry => the statistic type we store it as.
+    #
+    # Read this way round to match Fpl::SyncPlayers::SNAPSHOT_STATS. The two used
+    # to disagree, and a mapping whose direction you have to work out from the
+    # block that walks it is a mapping that gets read backwards.
     # Assists are a total rather than a rate, like the bonus beside them, because
     # that is how the forecast reads them and because a season's assists survive a
     # column of two decimal places where a rate of 0.08 a game does not.
     STAT_TYPES = {
-      "last_season_points" => "total_points",
-      "last_season_minutes" => "minutes",
-      "last_season_bonus" => "bonus",
-      "last_season_assists" => "assists"
+      "total_points" => "last_season_points",
+      "minutes" => "last_season_minutes",
+      "bonus" => "last_season_bonus",
+      "assists" => "last_season_assists"
     }.freeze
 
     # The same per-90 rates bootstrap publishes for the current season, worked out
@@ -36,15 +40,15 @@ module Fpl
     # counts. Nothing here changes what the forecast reads. It stores the other half
     # of each pair so the gap can be measured rather than argued about.
     RATE_TYPES = {
-      "last_season_expected_goals_per_90" => "expected_goals",
-      "last_season_expected_goal_involvements_per_90" => "expected_goal_involvements",
-      "last_season_expected_assists_per_90" => "expected_assists",
-      "last_season_goals_per_90" => "goals_scored",
-      "last_season_clean_sheets_per_90" => "clean_sheets",
-      "last_season_saves_per_90" => "saves",
-      "last_season_expected_goals_conceded_per_90" => "expected_goals_conceded",
-      "last_season_goals_conceded_per_90" => "goals_conceded",
-      "last_season_defensive_contribution_per_90" => "defensive_contribution"
+      "expected_goals" => "last_season_expected_goals_per_90",
+      "expected_goal_involvements" => "last_season_expected_goal_involvements_per_90",
+      "expected_assists" => "last_season_expected_assists_per_90",
+      "goals_scored" => "last_season_goals_per_90",
+      "clean_sheets" => "last_season_clean_sheets_per_90",
+      "saves" => "last_season_saves_per_90",
+      "expected_goals_conceded" => "last_season_expected_goals_conceded_per_90",
+      "goals_conceded" => "last_season_goals_conceded_per_90",
+      "defensive_contribution" => "last_season_defensive_contribution_per_90"
     }.freeze
 
     # Which season counts as last season, and nothing else does.
@@ -177,7 +181,7 @@ module Fpl
     end
 
     def totals(player, gameweek, season, now)
-      STAT_TYPES.filter_map do |type, key|
+      STAT_TYPES.filter_map do |key, type|
         value = season[key]
         next if value.nil?
 
@@ -191,7 +195,7 @@ module Fpl
       nineties = season["minutes"].to_f / MINUTES_IN_A_MATCH
       return [] unless nineties.positive?
 
-      RATE_TYPES.filter_map do |type, key|
+      RATE_TYPES.filter_map do |key, type|
         value = season[key]
         next if value.nil?
 
@@ -225,8 +229,10 @@ module Fpl
       Statistic.where(player_id: player.id, gameweek_id: gameweek.id, type: season_types).delete_all
     end
 
+    # The types we store a past season under, which is the far side of both
+    # mappings above.
     def season_types
-      @season_types ||= STAT_TYPES.keys + RATE_TYPES.keys
+      @season_types ||= STAT_TYPES.values + RATE_TYPES.values
     end
 
     def log_nothing_to_do

--- a/app/services/fpl/sync_player_histories.rb
+++ b/app/services/fpl/sync_player_histories.rb
@@ -22,7 +22,32 @@ module Fpl
       "total_points" => "last_season_points",
       "minutes" => "last_season_minutes",
       "bonus" => "last_season_bonus",
-      "assists" => "last_season_assists"
+      "assists" => "last_season_assists",
+      # How many times he was in the side, which is a different question from how
+      # much football he got through and the better one. Everybody plays most of a
+      # match when they start, so minutes divided by starts says almost nothing
+      # while the count of starts says whether he is picked. Nothing reads it yet.
+      "starts" => "last_season_starts",
+      # What he cost at either end of the campaign. A price is FPL's own valuation
+      # and the difference between the two is a season's verdict on him.
+      "start_cost" => "last_season_start_cost",
+      "end_cost" => "last_season_end_cost",
+      # The rest of what a season leaves behind. Counts and accumulations, stored
+      # as totals like the bonus above, so whatever reads them can decide for
+      # itself whether it wants a rate and what to divide by.
+      "bps" => "last_season_bps",
+      "influence" => "last_season_influence",
+      "creativity" => "last_season_creativity",
+      "threat" => "last_season_threat",
+      "ict_index" => "last_season_ict_index",
+      "recoveries" => "last_season_recoveries",
+      "tackles" => "last_season_tackles",
+      "clearances_blocks_interceptions" => "last_season_clearances_blocks_interceptions",
+      "own_goals" => "last_season_own_goals",
+      "penalties_missed" => "last_season_penalties_missed",
+      "penalties_saved" => "last_season_penalties_saved",
+      "yellow_cards" => "last_season_yellow_cards",
+      "red_cards" => "last_season_red_cards"
     }.freeze
 
     # The same per-90 rates bootstrap publishes for the current season, worked out
@@ -71,7 +96,7 @@ module Fpl
     # What we currently record from a past season. Bump it when that set changes
     # and every player is asked again on the next run, rather than being left with
     # a partial history that nothing notices.
-    RECORD_VERSION = 6.0
+    RECORD_VERSION = 7.0
 
     REQUEST_DELAY = 0.5 # seconds between requests, to stay a polite guest
 

--- a/app/services/fpl/sync_players.rb
+++ b/app/services/fpl/sync_players.rb
@@ -229,7 +229,39 @@ module Fpl
       "goals_conceded" => "season_goals_conceded",
       "clean_sheets" => "season_clean_sheets",
       "saves" => "season_saves",
+      # Named apart from the per-gameweek figures of the same name that
+      # SyncPerformances writes. These are the season's running accumulations and
+      # those are one match's worth; both are stored against the same player and
+      # gameweek, so sharing a type had the two syncs overwriting each other every
+      # hour, and the pipeline's order meant the season totals always lost.
       "starts" => "season_starts",
+      "recoveries" => "season_recoveries",
+      "tackles" => "season_tackles",
+      "clearances_blocks_interceptions" => "season_clearances_blocks_interceptions",
+      "dreamteam_count" => "season_dreamteam_count",
+      # Named apart from the transfers_in above, which is this gameweek's traffic
+      # from transfers_in_event. These two are the running season totals, and the
+      # unique index would have had the pair of them overwriting each other.
+      "transfers_in" => "season_transfers_in",
+      "transfers_out" => "season_transfers_out",
+      # What the market has done to his price: the move this gameweek, the move
+      # since August, and the pressure still building. The forecast already leans
+      # on what a player costs, and this is the same signal with a direction.
+      "cost_change_event" => "cost_change_event",
+      "cost_change_event_fall" => "cost_change_event_fall",
+      "cost_change_start" => "cost_change_start",
+      "cost_change_start_fall" => "cost_change_start_fall",
+      "price_change_percent" => "price_change_percent",
+      "price_change_hourly_rate" => "price_change_hourly_rate",
+      # Points per million, FPL's own two ways of asking whether he is worth it.
+      "value_form" => "value_form",
+      "value_season" => "value_season",
+      # FPL's own forecast for the week in progress, beside the one for the week
+      # ahead we already keep, and what he actually scored in it. Between them a
+      # published expectation can finally be marked against a result, which is
+      # the only outside benchmark our own accuracy has.
+      "ep_this" => "ep_this",
+      "event_points" => "event_points",
       "defensive_contribution" => "season_defensive_contribution",
       "own_goals" => "season_own_goals",
       "penalties_saved" => "season_penalties_saved",
@@ -238,11 +270,11 @@ module Fpl
       "red_cards" => "season_red_cards",
       # FPL's own indices and its bonus-points system: the numbers pundits quote and
       # managers argue over, published per player as running season figures.
-      "bps" => "bps",
-      "influence" => "influence",
-      "creativity" => "creativity",
-      "threat" => "threat",
-      "ict_index" => "ict_index",
+      "bps" => "season_bps",
+      "influence" => "season_influence",
+      "creativity" => "season_creativity",
+      "threat" => "season_threat",
+      "ict_index" => "season_ict_index",
       # Set-piece duty feeds underlying quality (1 = first choice). Nil when not on duty.
       "penalties_order" => "penalties_order",
       "corners_and_indirect_freekicks_order" => "corners_freekicks_order",

--- a/test/services/comparison_stats_test.rb
+++ b/test/services/comparison_stats_test.rb
@@ -38,7 +38,7 @@ class ComparisonStatsTest < ActiveSupport::TestCase
     reading(@salah, "season_points", 120)
     reading(@salah, "season_goals", 9)
     reading(@salah, "expected_goals_per_90", 0.55)
-    reading(@salah, "ict_index", 145.3)
+    reading(@salah, "season_ict_index", 145.3)
 
     labels = stats.flat_map(&:rows).map(&:label)
     assert_includes labels, "Form"

--- a/test/services/fpl/sync_players_test.rb
+++ b/test/services/fpl/sync_players_test.rb
@@ -258,9 +258,9 @@ class Fpl::SyncPlayersTest < ActiveSupport::TestCase
     assert_equal 9.0, stats["season_goals"]
     assert_in_delta 7.6, stats["season_expected_goals"], 0.001
     assert_equal 1.0, stats["season_own_goals"]
-    assert_equal 540.0, stats["bps"]
-    assert_in_delta 145.2, stats["ict_index"], 0.001
-    assert_in_delta 88.0, stats["threat"], 0.001
+    assert_equal 540.0, stats["season_bps"]
+    assert_in_delta 145.2, stats["season_ict_index"], 0.001
+    assert_in_delta 88.0, stats["season_threat"], 0.001
   end
 
   test "attaches snapshot statistics to the next gameweek pre-season" do


### PR DESCRIPTION
Came out of a full audit of statistics usage: who writes each figure, who reads it, and where the two disagree. Two commits, no change to any ranking.

## Two real bugs

**Two syncs were overwriting each other every hour.** `bps`, `influence`, `creativity`, `threat` and `ict_index` were claimed by both `SyncPlayers` (where they are the season's running accumulation) and `SyncPerformances` (where they are one match's worth). The unique key is player + gameweek + type, so the pair took turns, and `SyncPlayers` runs first in the pipeline so the season totals always lost.

Visible consequence: **`/compare` has been showing last week's ICT index and BPS under labels that read as season figures.** The snapshot's are now `season_bps` and the rest to match, and the comparison page reads those. Its own test was already called "persists the season totals and indices the comparison table reads" — it just wasn't asserting the right names.

**`season_types` was built from the wrong side of a mapping.** Surfaced by making the two sync services agree on direction (`SyncPlayers::SNAPSHOT_STATS` read `api_field => our_type`, `SyncPlayerHistories` read the reverse, so which side of the arrow meant what depended on which file you had open). Under the new direction the old `.keys` would have left a rejected old season in circulation instead of clearing it. The existing test caught it, which is the argument for the rename in one line.

## Coverage: 83 figures per sync cycle → 120

| | before | after | headline |
|---|---|---|---|
| Last season (`history_past`) | 13 | 29 | **`last_season_starts`** |
| Bootstrap snapshot | 43 | 59 | price movement, `ep_this`, `event_points` |
| Per-gameweek history | 27 | 32 | `selected`, `value`, `transfers_balance` |

**`last_season_starts` is the point of the exercise.** FPL has published it in `history_past` all along and we never stored it, which is why the model still infers whether a man is picked from how much football he got through. Everybody plays most of a match when they start, so minutes ÷ starts says almost nothing while the count of starts says everything. Nothing reads it yet; it is there to be read.

**`ep_this` + `event_points`** give FPL's own published expectation beside the result it was predicting. That is the only *outside* benchmark our accuracy work has, and unlike a re-run of our own forecast it is immune to the hindsight problem (statistics stamped against a gameweek are rewritten hourly after it finishes, so re-forecasting a finished week reads the score).

## Also in here

Four figures were being loaded into the forecast for every player every run and then multiplied by nothing: `expected_goal_involvements_per_90`, `clean_sheets_per_90` and both last-season halves. They went quiet when creating was priced from expected assists rather than the combined figure, and when a clean sheet became the chance of one rather than the share a side happened to keep. Still synced, still read by the comparison page; only the forecast stops asking.

## Deliberately not done

The 16 `*_rank` / `*_rank_type` fields. They are orderings of values we already store for all 612 players, so they carry nothing we cannot compute — `ExpectedPoints#crowd_order` already does exactly this for conviction. And a rank moves for everyone whenever anyone changes, so they would rewrite ~9,800 rows an hour to no end. Everything else FPL publishes numerically is now absorbed.

## Review notes

- **Rankings are byte-for-byte identical** across all four positions and all three horizons. Nothing added here is read by the forecast yet, and the removal is proof the four figures were dead rather than merely quiet.
- **`RECORD_VERSION` 6.0 → 7.0**, so the next `ff:hourly` re-asks every player's last-season history rather than skipping those already recorded. That is the expensive sync (one request per player, 3-minute budget), so expect several hourly runs to work through all 612.
- One correction to an earlier claim of mine, for the record: I had reported a bind-parameter ceiling on `Statistic.store` as a time bomb. It isn't one — Rails inlines values as literals in `upsert_all`, and 60,000 rows in a single statement completes fine. No change was made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)